### PR TITLE
Cygwin path support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,4 @@ Less configuration:
 Better Windows integration:
 
 * ANSI color escape sequences are also supported when running in Windows Console
+* Support for Cygwin paths in `-cp` and `-m`, resolved to their Windows counterparts

--- a/src/xp.runner/Command.cs
+++ b/src/xp.runner/Command.cs
@@ -95,13 +95,14 @@ namespace Xp.Runners
             proc.StartInfo.Arguments = string.Format(
                 "-C -q -d include_path=\".{0}{1}{0}{0}.{0}{2}\" {3} {4} {5}",
                 Paths.Separator,
-                string.Join(Paths.Separator, use.Concat(cmd.Options["modules"].Concat(ModulesFor(cmd)))),
-                string.Join(Paths.Separator, cmd.Options["classpath"].Concat(ClassPathFor(cmd))),
+                string.Join(Paths.Separator, use.Concat(cmd.Options["modules"].Concat(ModulesFor(cmd)).Select(Paths.Resolve))),
+                string.Join(Paths.Separator, cmd.Options["classpath"].Concat(ClassPathFor(cmd)).Select(Paths.Resolve)),
                 string.Join(" ", IniSettings(ini.Concat(configuration.GetArgs(runtime)))),
                 main,
                 string.Join(" ", ArgumentsFor(cmd).Select(args))
             );
 
+            // DEBUG Console.WriteLine("php {0}", proc.StartInfo.Arguments);
             return cmd.ExecutionModel.Execute(proc, encoding);
         }
     }

--- a/src/xp.runner/io/Cygwin.cs
+++ b/src/xp.runner/io/Cygwin.cs
@@ -8,6 +8,7 @@ namespace Xp.Runners.IO
 {
     static class Cygwin
     {
+        private const string CYGDRIVE_PATH = "/cygdrive/";
         private const string INSTALLATIONS = @"Software\Cygwin\Installations";
         private static byte[] SYMLINK_COOKIE = new byte[] { 33, 60, 115, 121, 109, 108, 105, 110, 107, 62 };
         private static IEnumerable<string> cygpath;
@@ -55,9 +56,9 @@ namespace Xp.Runners.IO
         /// <summary>Resolve directory. Supports absolute paths and home directories</summary>
         public static string Resolve(string path)
         {
-            if (path.StartsWith("/cygdrive/"))
+            if (path.StartsWith(CYGDRIVE_PATH))
             {
-                return path["/cygdrive/".Length] + ":" + path.Substring("/cygdrive/".Length + 1);
+                return path[CYGDRIVE_PATH.Length] + ":" + path.Substring(CYGDRIVE_PATH.Length + 1);
             }
 
             var absolute = Expand(path).Replace("/", Path.DirectorySeparatorChar.ToString());

--- a/src/xp.runner/io/Cygwin.cs
+++ b/src/xp.runner/io/Cygwin.cs
@@ -27,7 +27,7 @@ namespace Xp.Runners.IO
 
             return installed.GetValueNames()
                 .Select(key => installed.GetValue(key) as string)
-                .Select(path => path.Replace(@"\??\", ""))
+                .Select(path => path.Replace(@"\??\", "").TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar)
             ;
         }
 
@@ -40,11 +40,7 @@ namespace Xp.Runners.IO
             }
 
             var absolute = path.Replace("/", Path.DirectorySeparatorChar.ToString());
-            return Installations()
-                .Where(Directory.Exists)
-                .Select(root => root + absolute)
-                .FirstOrDefault()
-            ;
+            return Installations().Where(Directory.Exists).Select(root => root + absolute).FirstOrDefault();
         }
 
         /// <summary>Checks whether a file is a cygwin symlink file, and resolves it. See the

--- a/src/xp.runner/io/Cygwin.cs
+++ b/src/xp.runner/io/Cygwin.cs
@@ -55,6 +55,11 @@ namespace Xp.Runners.IO
         /// <summary>Resolve directory. Supports absolute paths and home directories</summary>
         public static string Resolve(string path)
         {
+            if (path.StartsWith("/cygdrive/"))
+            {
+                return path["/cygdrive/".Length] + ":" + path.Substring("/cygdrive/".Length + 1);
+            }
+
             var absolute = Expand(path).Replace("/", Path.DirectorySeparatorChar.ToString());
             return Installations()
                 .Where(Directory.Exists)

--- a/src/xp.runner/io/Cygwin.cs
+++ b/src/xp.runner/io/Cygwin.cs
@@ -36,23 +36,6 @@ namespace Xp.Runners.IO
             return cygpath;
         }
 
-        /// <summary>Expands home directories in path</summary>
-        public static string Expand(string path)
-        {
-            if ("~" == path || path.StartsWith("~/"))  // ~ = /home/$USER, ~/bin := /home/$USER/bin
-            {
-                return "/home" + Path.DirectorySeparatorChar + Environment.UserName + path.Substring(1);
-            }
-            else if (path.StartsWith("~"))             // ~thekid/bin := /home/thekid/bin
-            {
-                return "/home" + Path.DirectorySeparatorChar + path.Substring(1);
-            }
-            else
-            {
-                return path;
-            }
-        }
-
         /// <summary>Resolve directory. Supports absolute paths and home directories</summary>
         public static string Resolve(string path)
         {
@@ -61,7 +44,7 @@ namespace Xp.Runners.IO
                 return path[CYGDRIVE_PATH.Length] + ":" + path.Substring(CYGDRIVE_PATH.Length + 1);
             }
 
-            var absolute = Expand(path).Replace("/", Path.DirectorySeparatorChar.ToString());
+            var absolute = path.Replace("/", Path.DirectorySeparatorChar.ToString());
             return Installations()
                 .Where(Directory.Exists)
                 .Select(root => root + absolute)

--- a/src/xp.runner/io/Cygwin.cs
+++ b/src/xp.runner/io/Cygwin.cs
@@ -1,0 +1,85 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+using Microsoft.Win32;
+
+namespace Xp.Runners.IO
+{
+    static class Cygwin
+    {
+        private const string INSTALLATIONS = @"Software\Cygwin\Installations";
+        private static byte[] SYMLINK_COOKIE = new byte[] { 33, 60, 115, 121, 109, 108, 105, 110, 107, 62 };
+        private static IEnumerable<string> cygpath;
+
+        /// <summary>Determine whether we're runnning inside Cygwin</summary>
+        public static bool Active { get { return null != Environment.GetEnvironmentVariable("SHELL"); } }
+
+        /// <summary>Determine Cygwin installation directories. Caches information</summary>
+        public static IEnumerable<string> Installations(bool cached = true)
+        {
+            if (cygpath == null || !cached)
+            {
+                var installed = Registry.CurrentUser.OpenSubKey(INSTALLATIONS) ?? Registry.LocalMachine.OpenSubKey(INSTALLATIONS);
+                if (null == installed)
+                {
+                    throw new NotSupportedException("Cannot determine Cygwin path via registry [" + INSTALLATIONS + "]");
+                }
+
+                cygpath = installed.GetValueNames()
+                    .Select(key => installed.GetValue(key) as string)
+                    .Select(path => path.Replace(@"\??\", ""))
+                    .ToArray()
+                ;
+            }
+            return cygpath;
+        }
+
+        /// <summary>Expands home directories in path</summary>
+        public static string Expand(string path)
+        {
+            if ("~" == path || path.StartsWith("~/"))  // ~ = /home/$USER, ~/bin := /home/$USER/bin
+            {
+                return "/home" + Path.DirectorySeparatorChar + Environment.UserName + path.Substring(1);
+            }
+            else if (path.StartsWith("~"))             // ~thekid/bin := /home/thekid/bin
+            {
+                return "/home" + Path.DirectorySeparatorChar + path.Substring(1);
+            }
+            else
+            {
+                return path;
+            }
+        }
+
+        /// <summary>Resolve directory. Supports absolute paths and home directories</summary>
+        public static string Resolve(string path)
+        {
+            var absolute = Expand(path).Replace("/", Path.DirectorySeparatorChar.ToString());
+            return Installations()
+                .Where(Directory.Exists)
+                .Select(root => root + absolute)
+                .FirstOrDefault()
+            ;
+        }
+
+        /// <summary>Checks whether a file is a cygwin symlink file, and resolves it. See the
+        /// Cygwin docs, https://cygwin.com/cygwin-ug-net/using.html#pathnames-symlinks</summary>
+        public static string TryResolveSymlinkFile(FileInfo info)
+        {
+            if ((info.Attributes & FileAttributes.System) != FileAttributes.System) return null;
+
+            using (var stream = info.OpenRead())
+            {
+                var cookie = new byte[SYMLINK_COOKIE.Length];
+                stream.Read(cookie, 0, SYMLINK_COOKIE.Length);
+                if (!cookie.SequenceEqual(SYMLINK_COOKIE)) return null;
+
+                using (var text = new StreamReader(stream, true))
+                {
+                    return text.ReadToEnd().TrimEnd('\0');
+                }
+            }
+        }
+    }
+}

--- a/src/xp.runner/io/Cygwin.cs
+++ b/src/xp.runner/io/Cygwin.cs
@@ -36,7 +36,7 @@ namespace Xp.Runners.IO
             return cygpath;
         }
 
-        /// <summary>Resolve directory. Supports absolute paths and home directories</summary>
+        /// <summary>Resolve directory. Supports /cygdrive and absolute paths</summary>
         public static string Resolve(string path)
         {
             if (path.StartsWith(CYGDRIVE_PATH))

--- a/src/xp.runner/io/Paths.cs
+++ b/src/xp.runner/io/Paths.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Text;
 using System.IO;
+using System.Linq;
 using System.Collections.Generic;
 
 namespace Xp.Runners.IO
@@ -55,20 +56,32 @@ namespace Xp.Runners.IO
             }
         }
 
-        /// <summary>Resolve a path. If the path is actually a shell link (.lnk file), this link's target path is used</summary>
+        /// <summary>Resolve a path. If we're inside Cygwin, try to resolve absolute paths and
+        /// paths pointing to home directories relative to its installation directory. Otherwise,
+        /// if the file doesn't exist or is not a directory, also check for shortcuts and symlinks</summary>
         public static string Resolve(string path)
         {
+            if (Cygwin.Active && path.StartsWith("/") || path.StartsWith("~"))
+            {
+                path = Cygwin.Resolve(path) ?? path;
+            }
+
             var info = new FileInfo(path);
             var normalized = info.FullName.TrimEnd(Path.DirectorySeparatorChar);
+
             if (!info.Exists)
             {
                 var link = normalized + ".lnk";
-                if (File.Exists(link)) 
-                {
-                    return Shortcuts.Resolve(link);
-                }
+                return File.Exists(link) ? Shortcuts.Resolve(link) : normalized;
             }
-            return normalized;
+            else if ((info.Attributes & FileAttributes.Directory) == FileAttributes.Directory)
+            {
+                return normalized;
+            }
+            else
+            {
+                return Cygwin.TryResolveSymlinkFile(info) ?? normalized;
+            }
         }
 
         /// <summary>Translate a list of paths</summary>

--- a/src/xp.runner/io/Paths.cs
+++ b/src/xp.runner/io/Paths.cs
@@ -61,7 +61,7 @@ namespace Xp.Runners.IO
         /// if the file doesn't exist or is not a directory, also check for shortcuts and symlinks</summary>
         public static string Resolve(string path)
         {
-            if (Cygwin.Active && path.StartsWith("/") || path.StartsWith("~"))
+            if (Cygwin.Active && path.StartsWith("/"))
             {
                 path = Cygwin.Resolve(path) ?? path;
             }


### PR DESCRIPTION
This pull request adds support for Cygwin paths in `-cp` and `-m`, including Cygwin symlinks.
### What happens internally

Assume we're inside a Cygwin Terminal:

```
$ xp -cp ~/devel/xp/sequence/ ...
# Expanded by bash
# Passed to C# as /home/$USER/devel/xp/sequence/
# Cygwin environment detected via getenv("SHELL")
# Cygwin installation path(s) determined via registry, HKCU\Software\Cygwin\Installations
# Mapped to Windows directory, passed to PHP as C:\tools\cygwin\home\$USER\deve\xp\sequence
```
