### PR TITLE
Compile using "mono"

### DIFF
--- a/src/xp.runner.test/PathsTest.cs
+++ b/src/xp.runner.test/PathsTest.cs
@@ -112,7 +112,7 @@ namespace Xp.Runners.Test
         [Fact]
         public void translate_home_path()
         {
-            var home = Environment.GetEnvironmentVariable("HOME") ?? Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+            var home = Paths.Home();
             Assert.Equal(
                 new string[] { home },
                 Paths.Translate(".", new string[] { "~" }).ToArray()
@@ -122,7 +122,7 @@ namespace Xp.Runners.Test
         [Fact]
         public void translate_path_inside_home()
         {
-            var home = Environment.GetEnvironmentVariable("HOME") ?? Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+            var home = Paths.Home();
             Assert.Equal(
                 new string[] { Paths.Compose(home, "devel") },
                 Paths.Translate(".", new string[] { "~/devel" }).ToArray()

--- a/src/xp.runner/Command.cs
+++ b/src/xp.runner/Command.cs
@@ -21,7 +21,7 @@ namespace Xp.Runners
 
             if (Environment.OSVersion.Platform == PlatformID.Unix || Environment.OSVersion.Platform == PlatformID.MacOSX)
             {
-                yield return Paths.Compose(Environment.GetEnvironmentVariable("HOME"), ".composer", VENDOR);
+                yield return Paths.Compose(Paths.Home(), ".composer", VENDOR);
             }
             else
             {

--- a/src/xp.runner/commands/Plugin.cs
+++ b/src/xp.runner/commands/Plugin.cs
@@ -13,9 +13,7 @@ namespace Xp.Runners.Commands
     {
         private EntryPoint entry;
         private IEnumerable<string> modules;
-        private static DataContractJsonSerializer json = new DataContractJsonSerializer(typeof(Composer), new DataContractJsonSerializerSettings {
-            UseSimpleDictionaryFormat = true
-        });
+        private static DataContractJsonSerializer json = new DataContractJsonSerializer(typeof(Composer), "root");
 
         public Plugin(string name)
         {

--- a/src/xp.runner/exec/ExecutionModel.cs
+++ b/src/xp.runner/exec/ExecutionModel.cs
@@ -24,19 +24,19 @@ namespace Xp.Runners.Exec
         /// <summary>Run the process and return its exitcode</summary>
         protected int Run(Process proc, Encoding encoding)
         {
-            var original = Console.OutputEncoding;
+            // var original = Console.OutputEncoding;
 
-            proc.StartInfo.RedirectStandardOutput = !Console.IsOutputRedirected;
-            proc.StartInfo.RedirectStandardError = !Console.IsErrorRedirected;
+            // proc.StartInfo.RedirectStandardOutput = !Console.IsOutputRedirected;
+            // proc.StartInfo.RedirectStandardError = !Console.IsErrorRedirected;
 
-            Console.CancelKeyPress += (sender, args) => Console.OutputEncoding = original;
-            Console.OutputEncoding = encoding;
+            // Console.CancelKeyPress += (sender, args) => Console.OutputEncoding = original;
+            // Console.OutputEncoding = encoding;
 
             try
             {
                 proc.Start();
-                var stdout = Console.IsOutputRedirected ? passThrough : Redirect(proc.StandardOutput, new ANSISupport(Console.Out));
-                var stderr = Console.IsErrorRedirected ? passThrough : Redirect(proc.StandardError, new ANSISupport(Console.Error));
+                var stdout = passThrough; // Console.IsOutputRedirected ? passThrough : Redirect(proc.StandardOutput, new ANSISupport(Console.Out));
+                var stderr = passThrough; // Console.IsErrorRedirected ? passThrough : Redirect(proc.StandardError, new ANSISupport(Console.Error));
 
                 proc.WaitForExit();
                 stdout.WaitForEnd();
@@ -49,7 +49,7 @@ namespace Xp.Runners.Exec
             }
             finally
             {
-                Console.OutputEncoding = original;
+                // Console.OutputEncoding = original;
                 proc.Close();
             }
         }

--- a/src/xp.runner/exec/ExecutionModel.cs
+++ b/src/xp.runner/exec/ExecutionModel.cs
@@ -37,13 +37,17 @@ namespace Xp.Runners.Exec
         /// <summary>Run the process and return its exitcode</summary>
         protected int Run(Process proc, Encoding encoding)
         {
-            //var original = Console.OutputEncoding;
+            Encoding original = null;
+
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                original = Console.OutputEncoding;
+                Console.CancelKeyPress += (sender, args) => Console.OutputEncoding = original;
+                Console.OutputEncoding = encoding;
+            }
 
             proc.StartInfo.RedirectStandardOutput = RewriteANSI(Console.IsOutputRedirected);
             proc.StartInfo.RedirectStandardError = RewriteANSI(Console.IsErrorRedirected);
-
-            // Console.CancelKeyPress += (sender, args) => Console.OutputEncoding = original;
-            // Console.OutputEncoding = encoding;
 
             try
             {
@@ -62,7 +66,7 @@ namespace Xp.Runners.Exec
             }
             finally
             {
-                // Console.OutputEncoding = original;
+                if (original != null) Console.OutputEncoding = original;
                 proc.Close();
             }
         }

--- a/src/xp.runner/exec/ExecutionModel.cs
+++ b/src/xp.runner/exec/ExecutionModel.cs
@@ -21,13 +21,26 @@ namespace Xp.Runners.Exec
             return reader;
         }
 
+        /// <summary>Check whether it's necessary to rewrite ANSI color</summary>
+        private bool RewriteANSI(bool redirected)
+        {
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                return !redirected;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
         /// <summary>Run the process and return its exitcode</summary>
         protected int Run(Process proc, Encoding encoding)
         {
-            // var original = Console.OutputEncoding;
+            //var original = Console.OutputEncoding;
 
-            // proc.StartInfo.RedirectStandardOutput = !Console.IsOutputRedirected;
-            // proc.StartInfo.RedirectStandardError = !Console.IsErrorRedirected;
+            proc.StartInfo.RedirectStandardOutput = RewriteANSI(Console.IsOutputRedirected);
+            proc.StartInfo.RedirectStandardError = RewriteANSI(Console.IsErrorRedirected);
 
             // Console.CancelKeyPress += (sender, args) => Console.OutputEncoding = original;
             // Console.OutputEncoding = encoding;
@@ -35,8 +48,8 @@ namespace Xp.Runners.Exec
             try
             {
                 proc.Start();
-                var stdout = passThrough; // Console.IsOutputRedirected ? passThrough : Redirect(proc.StandardOutput, new ANSISupport(Console.Out));
-                var stderr = passThrough; // Console.IsErrorRedirected ? passThrough : Redirect(proc.StandardError, new ANSISupport(Console.Error));
+                var stdout = proc.StartInfo.RedirectStandardOutput ? Redirect(proc.StandardOutput, new ANSISupport(Console.Out)) : passThrough;
+                var stderr = proc.StartInfo.RedirectStandardError ? Redirect(proc.StandardError, new ANSISupport(Console.Error)) : passThrough;
 
                 proc.WaitForExit();
                 stdout.WaitForEnd();

--- a/src/xp.runner/io/Paths.cs
+++ b/src/xp.runner/io/Paths.cs
@@ -56,6 +56,12 @@ namespace Xp.Runners.IO
             }
         }
 
+        /// <summary>Returns home path</summary>
+        public static string Home()
+        {
+            return Environment.GetEnvironmentVariable("HOME") ?? Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+        }
+
         /// <summary>Resolve a path. If the path is actually a shell link (.lnk file), this link's target path is used</summary>
         public static string Resolve(string path)
         {
@@ -75,7 +81,7 @@ namespace Xp.Runners.IO
         /// <summary>Translate a list of paths</summary>
         public static IEnumerable<string> Translate(string root, string[] paths)
         {
-            var homePath = Environment.GetEnvironmentVariable("HOME") ?? Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+            var homePath = Home();
             var directorySeparator = new string(new char[] { Path.DirectorySeparatorChar });
             foreach (var path in paths)
             {


### PR DESCRIPTION
Implements #15 in such a way that `./xp.exe -v` works:

![mono-run](https://cloud.githubusercontent.com/assets/696742/12251597/74e57f88-b8d0-11e5-880f-d9885cbc2b93.png)
