### PR TITLE
Implement "xp ar ..." as replacement for "xar"

### DIFF
--- a/src/xp.runner.test/CommandLineTest.cs
+++ b/src/xp.runner.test/CommandLineTest.cs
@@ -66,6 +66,13 @@ namespace Xp.Runners.Test
             Assert.IsType<Dump>(new CommandLine(new string[] { arg }).Command);
         }
 
+        [Theory]
+        [InlineData("ar")]
+        public void ar(string arg)
+        {
+            Assert.IsType<Ar>(new CommandLine(new string[] { arg }).Command);
+        }
+
         [Fact]
         public void classpath_initially_empty()
         {

--- a/src/xp.runner/commands/Ar.cs
+++ b/src/xp.runner/commands/Ar.cs
@@ -1,0 +1,16 @@
+using System.Linq;
+using System.Collections.Generic;
+using Xp.Runners;
+
+namespace Xp.Runners.Commands
+{
+    /// <summary>ar $flags [$options]</summary>
+    public class Ar : Command
+    {
+        /// <summary>Command line arguments.</summary>
+        protected override IEnumerable<string> ArgumentsFor(CommandLine cmd)
+        {
+            return (new string[] { "xp.xar.Runner" }).Concat(cmd.Arguments);
+        }
+    }
+}

--- a/src/xp.runner/commands/Help.cs
+++ b/src/xp.runner/commands/Help.cs
@@ -41,6 +41,11 @@ namespace Xp.Runners.Commands
                 arguments = new string[] { HELP, Topic(plugin.EntryPoint.Package.Replace('.', '/'), topic[1]) };
                 modules = plugin.Modules;
             }
+            else if (null != Type.GetType("Xp.Runners.Commands." + arg.UpperCaseFirst()))
+            {
+                arguments = new string[] { HELP, Topic("xp/runtime", arg) };
+                modules = new string[] { };
+            }
             else
             {
                 var plugin = new Plugin(arg);


### PR DESCRIPTION
See https://github.com/xp-framework/rfc/issues/303 and https://github.com/xp-framework/core/issues/126
- [x] The subcommand itself
- [x] A help screen - see also xp-framework/core@1b23d21

![xp-ar-command](https://cloud.githubusercontent.com/assets/696742/12538038/d57a08b6-c2ce-11e5-8175-62b3120a0d20.png)
