### PR TITLE
Implement "xp -serve" to set serve execution model

### DIFF
--- a/src/xp.runner.test/CommandLineTest.cs
+++ b/src/xp.runner.test/CommandLineTest.cs
@@ -151,6 +151,12 @@ namespace Xp.Runners.Test
             Assert.IsType<RunWatching>(new CommandLine(new string[] { "-watch", "." }).ExecutionModel);
         }
 
+        [Fact]
+        public void serve_execution_model()
+        {
+            Assert.IsType<Serve>(new CommandLine(new string[] { "-serve" }).ExecutionModel);
+        }
+
         [Theory]
         [InlineData(".")]
         [InlineData("src")]

--- a/src/xp.runner/CommandLine.cs
+++ b/src/xp.runner/CommandLine.cs
@@ -108,6 +108,11 @@ namespace Xp.Runners
                     executionModel = new RunWatching(argv[++i]);
                     offset = i + 1;
                 }
+                else if ("-serve".Equals(argv[i]))
+                {
+                    executionModel = new Serve();
+                    offset = i + 1;
+                }
                 else if (IsOption(argv[i]))
                 {
                     throw new ArgumentException("Unknown option `" + argv[i] + "`");

--- a/src/xp.runner/exec/ExecutionModel.cs
+++ b/src/xp.runner/exec/ExecutionModel.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Xp.Runners.Exec
 {
@@ -35,7 +36,7 @@ namespace Xp.Runners.Exec
         }
 
         /// <summary>Run the process and return its exitcode</summary>
-        protected int Run(Process proc, Encoding encoding)
+        protected int Run(Process proc, Encoding encoding, Action started = null)
         {
             Encoding original = null;
 
@@ -54,6 +55,11 @@ namespace Xp.Runners.Exec
                 proc.Start();
                 var stdout = proc.StartInfo.RedirectStandardOutput ? Redirect(proc.StandardOutput, new ANSISupport(Console.Out)) : passThrough;
                 var stderr = proc.StartInfo.RedirectStandardError ? Redirect(proc.StandardError, new ANSISupport(Console.Error)) : passThrough;
+
+                if (null != started)
+                {
+                    Task.Factory.StartNew(started);
+                }
 
                 proc.WaitForExit();
                 stdout.WaitForEnd();

--- a/src/xp.runner/exec/Serve.cs
+++ b/src/xp.runner/exec/Serve.cs
@@ -5,9 +5,9 @@ using System.Diagnostics;
 
 namespace Xp.Runners.Exec
 {
-
     public class Serve : ExecutionModel
     {
+        const int WAIT_FOR_STARTUP = 1;
 
         /// <summary>Execute the process and return its exitcode</summary>
         public override int Execute(Process proc, Encoding encoding)
@@ -16,7 +16,7 @@ namespace Xp.Runners.Exec
             {
                 Console.Out.WriteLine("[xp::serve#{0}] - Press <Enter> to exit", proc.Id);
 
-                System.Threading.Thread.Sleep(1000);
+                System.Threading.Thread.Sleep(WAIT_FOR_STARTUP * 1000);
                 if (proc.HasExited) return;
 
                 Console.Read();

--- a/src/xp.runner/exec/Serve.cs
+++ b/src/xp.runner/exec/Serve.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Diagnostics;
+
+namespace Xp.Runners.Exec
+{
+
+    public class Serve : ExecutionModel
+    {
+
+        /// <summary>Execute the process and return its exitcode</summary>
+        public override int Execute(Process proc, Encoding encoding)
+        {
+            Run(proc, encoding, () =>
+            {
+                Console.Out.WriteLine("[xp::serve#{0}] - Press <Enter> to exit", proc.Id);
+
+                System.Threading.Thread.Sleep(1000);
+                if (proc.HasExited) return;
+
+                Console.Read();
+                proc.Kill();
+                Console.Out.WriteLine("[xp::serve#{0}] - Shutting down...", proc.Id);
+            });
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
``` sh
$ DOCUMENT_ROOT=doc_root XP_RT=5.6 xp -serve xp.scriptlet.Server . etc
```

This will run a web with the Server implementation from the scriptlet library, using the current directory as web root and etc/ as config file directory. This will be implemented as a subcommand in the future

See #2
