### PR TITLE
Implement "-supervise" execution model

### DIFF
--- a/src/xp.runner.test/CommandLineTest.cs
+++ b/src/xp.runner.test/CommandLineTest.cs
@@ -151,6 +151,12 @@ namespace Xp.Runners.Test
             Assert.IsType<RunWatching>(new CommandLine(new string[] { "-watch", "." }).ExecutionModel);
         }
 
+        [Fact]
+        public void supervise_execution_model()
+        {
+            Assert.IsType<Supervise>(new CommandLine(new string[] { "-supervise", "." }).ExecutionModel);
+        }
+
         [Theory]
         [InlineData(".")]
         [InlineData("src")]

--- a/src/xp.runner/CommandLine.cs
+++ b/src/xp.runner/CommandLine.cs
@@ -108,6 +108,11 @@ namespace Xp.Runners
                     executionModel = new RunWatching(argv[++i]);
                     offset = i + 1;
                 }
+                else if ("-supervise".Equals(argv[i]))
+                {
+                    executionModel = new Supervise();
+                    offset = i + 1;
+                }
                 else if (IsOption(argv[i]))
                 {
                     throw new ArgumentException("Unknown option `" + argv[i] + "`");

--- a/src/xp.runner/exec/ExecutionModel.cs
+++ b/src/xp.runner/exec/ExecutionModel.cs
@@ -58,6 +58,7 @@ namespace Xp.Runners.Exec
                 proc.WaitForExit();
                 stdout.WaitForEnd();
                 stderr.WaitForEnd();
+
                 return proc.ExitCode;
             }
             catch (SystemException e)

--- a/src/xp.runner/exec/ExecutionModel.cs
+++ b/src/xp.runner/exec/ExecutionModel.cs
@@ -35,9 +35,10 @@ namespace Xp.Runners.Exec
         }
 
         /// <summary>Run the process and return its exitcode</summary>
-        protected int Run(Process proc, Encoding encoding)
+        protected int Run(Process proc, Encoding encoding, Func<int> wait = null)
         {
             Encoding original = null;
+            int result;
 
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)
             {
@@ -55,11 +56,20 @@ namespace Xp.Runners.Exec
                 var stdout = proc.StartInfo.RedirectStandardOutput ? Redirect(proc.StandardOutput, new ANSISupport(Console.Out)) : passThrough;
                 var stderr = proc.StartInfo.RedirectStandardError ? Redirect(proc.StandardError, new ANSISupport(Console.Error)) : passThrough;
 
-                proc.WaitForExit();
+                if (null == wait)
+                {
+                    proc.WaitForExit();
+                    result = proc.ExitCode;
+                }
+                else
+                {
+                    result = wait();
+                }
+
                 stdout.WaitForEnd();
                 stderr.WaitForEnd();
 
-                return proc.ExitCode;
+                return result;
             }
             catch (SystemException e)
             {

--- a/src/xp.runner/exec/StdStreamReader.cs
+++ b/src/xp.runner/exec/StdStreamReader.cs
@@ -41,7 +41,10 @@ namespace Xp.Runners.Exec
         }
 
         /// <summary>Wait until we've read until the end</summary>
-        public bool WaitForEnd() { return done.WaitOne(); }
+        public bool WaitForEnd()
+        {
+            return done.WaitOne();
+        }
 
         public void ReaderCallback(IAsyncResult result)
         {

--- a/src/xp.runner/exec/Supervise.cs
+++ b/src/xp.runner/exec/Supervise.cs
@@ -1,0 +1,31 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Xp.Runners.Exec
+{
+    public class Supervise : ExecutionModel
+    {
+        const int WAIT_BEFORE_RESPAWN = 1;
+
+        /// <summary>Execute the process and return its exitcode</summary>
+        public override int Execute(Process proc, Encoding encoding)
+        {
+            int code = -1;
+            do
+            {
+                if (code > 0)
+                {
+                    Console.WriteLine("*** Process exited with exitcode {0}, respawning...", code);
+                    Thread.Sleep(WAIT_BEFORE_RESPAWN * 1000);
+                }
+
+                code = Run(proc, encoding);
+            } while (code > 0);
+
+            return code;
+        }
+    }
+}

--- a/src/xp.runner/exec/Supervise.cs
+++ b/src/xp.runner/exec/Supervise.cs
@@ -25,11 +25,13 @@ namespace Xp.Runners.Exec
                 {
                     if (elapsed.Seconds < WAIT_FOR_STARTUP)
                     {
-                        Console.WriteLine("*** Process exited too quickly, aborting", code);
+                        Console.WriteLine();
+                        Console.WriteLine("*** Process exited too quickly, aborting");
                         return code;
                     }
                     else
                     {
+                        Console.WriteLine();
                         Console.WriteLine("*** Process exited with exitcode {0}, respawning...", code);
                         Thread.Sleep(WAIT_BEFORE_RESPAWN * 1000);
                     }

--- a/src/xp.runner/exec/Supervise.cs
+++ b/src/xp.runner/exec/Supervise.cs
@@ -9,6 +9,7 @@ namespace Xp.Runners.Exec
     public class Supervise : ExecutionModel
     {
         const int WAIT_BEFORE_RESPAWN = 1;
+        const int WAIT_FOR_STARTUP = 2;
 
         /// <summary>Execute the process and return its exitcode</summary>
         public override int Execute(Process proc, Encoding encoding)
@@ -16,13 +17,23 @@ namespace Xp.Runners.Exec
             int code = -1;
             do
             {
+                var start = DateTime.Now;
+                code = Run(proc, encoding);
+                var elapsed = DateTime.Now - start;
+
                 if (code > 0)
                 {
-                    Console.WriteLine("*** Process exited with exitcode {0}, respawning...", code);
-                    Thread.Sleep(WAIT_BEFORE_RESPAWN * 1000);
+                    if (elapsed.Seconds < WAIT_FOR_STARTUP)
+                    {
+                        Console.WriteLine("*** Process exited too quickly, aborting", code);
+                        return code;
+                    }
+                    else
+                    {
+                        Console.WriteLine("*** Process exited with exitcode {0}, respawning...", code);
+                        Thread.Sleep(WAIT_BEFORE_RESPAWN * 1000);
+                    }
                 }
-
-                code = Run(proc, encoding);
             } while (code > 0);
 
             return code;

--- a/src/xp.runner/exec/Supervise.cs
+++ b/src/xp.runner/exec/Supervise.cs
@@ -14,11 +14,38 @@ namespace Xp.Runners.Exec
         /// <summary>Execute the process and return its exitcode</summary>
         public override int Execute(Process proc, Encoding encoding)
         {
+            var cancel = new ManualResetEvent(false);
+            var buffer = new byte[256];
+            var stdin = Console.OpenStandardInput();
+            var result = stdin.BeginRead(buffer, 0, buffer.Length, ar => cancel.Set(), null);
+
+            proc.StartInfo.RedirectStandardInput = true;
+            proc.EnableRaisingEvents = true;
+            proc.Exited += (sender, args) => cancel.Set();
+
             int code = -1;
             do
             {
                 var start = DateTime.Now;
-                code = Run(proc, encoding);
+                code = Run(proc, encoding, () =>
+                {
+                    cancel.Reset();
+                    proc.StandardInput.Close();
+                    cancel.WaitOne();
+
+                    if (result.IsCompleted)
+                    {
+                        Console.WriteLine("==> Shut down");
+                        stdin.EndRead(result);
+                        proc.Kill();
+                        return 0;
+                    }
+                    else
+                    {
+                        proc.WaitForExit();
+                        return proc.ExitCode;
+                    }
+                });
                 var elapsed = DateTime.Now - start;
 
                 if (code > 0)
@@ -26,7 +53,8 @@ namespace Xp.Runners.Exec
                     if (elapsed.Seconds < WAIT_FOR_STARTUP)
                     {
                         Console.WriteLine();
-                        Console.WriteLine("*** Process exited too quickly, aborting");
+                        Console.WriteLine("*** Process exited right after being started, aborting");
+                        stdin.Close();
                         return code;
                     }
                     else
@@ -38,6 +66,8 @@ namespace Xp.Runners.Exec
                 }
             } while (code > 0);
 
+            // Either via user-interactive shutdown or via runtime exiting itself
+            stdin.Close();
             return code;
         }
     }


### PR DESCRIPTION
See xp-runners/reference#24
- [x] Starts the runtime
- [x] On non-zero exit, restarts it after one second - much like http://supervisord.org/
- [x] Prevent "endless loops": Shuts down if command exits after less than two seconds at start
- [x] Shut down on when user presses `ENTER`.
## Example

``` sh
$ XP_RT=5.6 xp -supervise -m ../devel/xp/scriptlet/ web -r doc_root
--> Startup serve(localhost:8080 & [])
# ...
# Killed by out of memory / kill -9 via command line / etc.

*** Process exited with exitcode 1, respawning...
--> Startup serve(localhost:8080 & [])
# ...
Uncaught exception: Exception lang.reflect.TargetInvocationException (xp.scriptlet.WebRunner::…)
  at lang.reflect.Method::invoke(NULL, array[1]) [line 350 of class-main.php]
Caused by Exception lang.Error (Call to undefined method …::getClassName()…)
  at de.thekid.dialog.Album::getClassName() [line 97 of …]
  at xp.scriptlet.HttpProtocol::handleData(peer.BSDSocket{}) [line 181 of Server.class.php]
  at peer.server.Server::service() [line 191 of WebRunner.class.php]
  at xp.scriptlet.WebRunner::main(array[2]) [line 0 of StackTraceElement.class.php]
  at ReflectionMethod::invokeArgs(NULL, array[1]) [line 90 of Method.class.php]

*** Process exited with exitcode 255, respawning...
--> Startup serve(localhost:8080 & [])
# ...
```

``` sh
$ XP_RT=5.6 xp -supervise -m ../devel/xp/scriptlet/ web -r doc_root util.Date
Uncaught exception: Exception lang.reflect.TargetInvocationException (xp.scriptlet.WebRunner::…)
  at lang.reflect.Method::invoke(NULL, array[1]) [line 350 of class-main.php]
Caused by Exception lang.IllegalArgumentException (Expecting …, util.Date given)
  at xp.scriptlet.WebRunner::main(array[3]) [line 0 of StackTraceElement.class.php]
  at ReflectionMethod::invokeArgs(NULL, array[1]) [line 90 of Method.class.php]

*** Process exited too quickly, aborting
```
