### PR TITLE
fix call of mktemp, requires a template on OS X

### DIFF
--- a/bundle.sh
+++ b/bundle.sh
@@ -8,8 +8,8 @@ if [ -z ${TRAVIS_TAG-} ]; then
   exit 1
 fi
 
-if [ -z $TMPDIR ]; then
-    TEMPDIR=$TMPDIR
+if [ -z "$TMPDIR" ]; then
+    TEMPDIR="$TMPDIR"
 else
     TEMPDIR="/tmp"
 fi

--- a/bundle.sh
+++ b/bundle.sh
@@ -8,7 +8,13 @@ if [ -z ${TRAVIS_TAG-} ]; then
   exit 1
 fi
 
-BUILD=$(mktemp -d)
+if [ -z $TMPDIR ]; then
+    TEMPDIR=$TMPDIR
+else
+    TEMPDIR="/tmp"
+fi
+
+BUILD=$(mktemp -d "$TEMPDIR/tmp.XXXXXXXXXX")
 SOURCES="bootstrap.php class-main.php class-path.php scan-path.php web-main.php xar-support.php entry.php"
 TARGETS="class-main.php web-main.php"
 
@@ -21,7 +27,7 @@ done
 # Replace
 curl -sSL https://raw.githubusercontent.com/xp-runners/main/master/inline.pl > $BUILD/inline.pl
 for target in $TARGETS ; do
-  cat $BUILD/$target | perl $BUILD/inline.pl $BUILD
+  cat $BUILD/$target | perl $BUILD/inline.pl $BUILD > $target
 done
 
 # Done

--- a/setup.sh.in
+++ b/setup.sh.in
@@ -122,8 +122,8 @@ printf "\033[32;1mXP Runners setup (@VERSION@)\033[0m\n"
 echo '(c) 2016 https://github.com/xp-runners/reference/'
 echo
 
-if [ -z $TMPDIR ]; then
-    TEMPDIR=$TMPDIR
+if [ -z "$TMPDIR" ]; then
+    TEMPDIR="$TMPDIR"
 else
     TEMPDIR="/tmp"
 fi

--- a/setup.sh.in
+++ b/setup.sh.in
@@ -122,7 +122,13 @@ printf "\033[32;1mXP Runners setup (@VERSION@)\033[0m\n"
 echo '(c) 2016 https://github.com/xp-runners/reference/'
 echo
 
-TEMPFILE=$(mktemp -u)
+if [ -z $TMPDIR ]; then
+    TEMPDIR=$TMPDIR
+else
+    TEMPDIR="/tmp"
+fi
+
+TEMPFILE=$(mktemp -u "$TEMPDIR/tmp.XXXXXXXXXX")
 SPACE='                  '
 MODE=Default
 CHECKS=Error
@@ -218,7 +224,7 @@ case $OS in
     ;;
 esac
 
-TARFILE=$(mktemp -u)
+TARFILE=$(mktemp -u "$TEMPDIR/tmp.XXXXXXXXXX")
 download https://bintray.com/artifact/download/xp-runners/generic/xp-runners_@VERSION@.tar.gz $TARFILE
 
 run 'Extract' "tar xvfz $TARFILE $EXE class-main.php web-main.php"


### PR DESCRIPTION
This PR fixes the problem that the `mktemp` command on OS X requires a template as argument, which is not required on the Linux version of the command.

Additionally as a byproduct it fixes the wrong call of the inline.pl script from which the output was not redirected to the target any more.
