### PR TITLE
Add runner version before xp.runtime.Version output

### DIFF
--- a/src/xp.runner/Command.cs
+++ b/src/xp.runner/Command.cs
@@ -75,7 +75,7 @@ namespace Xp.Runners
         }
 
         /// <summary>Entry point</summary>
-        public int Execute(CommandLine cmd, ConfigSource configuration)
+        public virtual int Execute(CommandLine cmd, ConfigSource configuration)
         {
             Initialize(cmd, configuration);
 

--- a/src/xp.runner/commands/Version.cs
+++ b/src/xp.runner/commands/Version.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Reflection;
 using System.Collections.Generic;
 using Xp.Runners;
+using Xp.Runners.IO;
 
 namespace Xp.Runners.Commands
 {
@@ -13,7 +14,7 @@ namespace Xp.Runners.Commands
         protected override IEnumerable<string> ArgumentsFor(CommandLine cmd)
         {
             var self = Assembly.GetExecutingAssembly();
-            Console.WriteLine("Runners {0} {{ .NET {1} }} @ {2}", self.GetName().Version, self.ImageRuntimeVersion, self.CodeBase);
+            Console.WriteLine("Runners {0} {{ .NET {1} }} @ {2}", self.GetName().Version, self.ImageRuntimeVersion, Paths.Binary());
             return new string[] { "xp.runtime.Version" };
         }
     }

--- a/src/xp.runner/commands/Version.cs
+++ b/src/xp.runner/commands/Version.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Linq;
+using System.Reflection;
 using System.Collections.Generic;
 using Xp.Runners;
 
@@ -10,6 +12,8 @@ namespace Xp.Runners.Commands
         /// <summary>Command line arguments.</summary>
         protected override IEnumerable<string> ArgumentsFor(CommandLine cmd)
         {
+            var self = Assembly.GetExecutingAssembly();
+            Console.WriteLine("Runners {0} {{ .NET {1} }} @ {2}", self.GetName().Version, self.ImageRuntimeVersion, self.CodeBase);
             return new string[] { "xp.runtime.Version" };
         }
     }

--- a/src/xp.runner/commands/Version.cs
+++ b/src/xp.runner/commands/Version.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Collections.Generic;
 using Xp.Runners;
 using Xp.Runners.IO;
+using Xp.Runners.Config;
 
 namespace Xp.Runners.Commands
 {
@@ -13,9 +14,17 @@ namespace Xp.Runners.Commands
         /// <summary>Command line arguments.</summary>
         protected override IEnumerable<string> ArgumentsFor(CommandLine cmd)
         {
+            return new string[] { "xp.runtime.Version" };
+        }
+
+
+        /// <summary>Entry point</summary>
+        public override int Execute(CommandLine cmd, ConfigSource configuration)
+        {
             var self = Assembly.GetExecutingAssembly();
             Console.WriteLine("Runners {0} {{ .NET {1} }} @ {2}", self.GetName().Version, self.ImageRuntimeVersion, Paths.Binary());
-            return new string[] { "xp.runtime.Version" };
+
+            return base.Execute(cmd, configuration);
         }
     }
 }

--- a/src/xp.runner/commands/Version.cs
+++ b/src/xp.runner/commands/Version.cs
@@ -22,7 +22,12 @@ namespace Xp.Runners.Commands
         public override int Execute(CommandLine cmd, ConfigSource configuration)
         {
             var self = Assembly.GetExecutingAssembly();
-            Console.WriteLine("Runners {0} {{ .NET {1} }} @ {2}", self.GetName().Version, self.ImageRuntimeVersion, Paths.Binary());
+            Console.WriteLine(
+                "Runners {0} {{ .NET {1} }} @ {2}",
+                self.GetName().Version,
+                self.ImageRuntimeVersion,
+                Paths.Binary()
+            );
 
             return base.Execute(cmd, configuration);
         }


### PR DESCRIPTION
Example:

``` sh
$ ./xp.exe -v
Runners 7.2.1.53 { .NET v4.0.30319 } @ C:\tools\...\xp.exe
XP 7.0.2-dev { PHP 7.0.0 & ZE 3.0.0 } @ Windows NT SLATE 10.0 build 10586 (Windows 10) i586
Copyright (c) 2001-2016 the XP group
FileSystemCL<~/devel/xp/core/src/main/php>
FileSystemCL<~/devel/xp/core/src/test/php>
FileSystemCL<~/devel/xp/core/src/main/resources>
FileSystemCL<~/devel/xp/core/src/test/resources>
FileSystemCL<.>
```

/cc @kiesel what do you think?
