### PR TITLE
No longer create *mkbundle'd* executables

### DIFF
--- a/bundle.sh
+++ b/bundle.sh
@@ -10,7 +10,6 @@ BUILD=$(mktemp -d "$temp/tmp.XXXXXXXXXX")
 SOURCES="bootstrap.php class-main.php class-path.php scan-path.php web-main.php xar-support.php entry.php"
 TARGETS="class-main.php web-main.php"
 EXE=$(pwd)/xp.exe
-BIN=$(pwd)/xp
 
 # Fetch
 for src in $SOURCES ; do
@@ -23,9 +22,6 @@ curl -sSL https://raw.githubusercontent.com/xp-runners/main/master/inline.pl > $
 for target in $TARGETS ; do
   cat $BUILD/$target | perl $BUILD/inline.pl $BUILD > $target
 done
-
-# Standalone XP
-mkbundle -o $BIN $EXE System.Core System.Runtime.Serialization Mono.Posix -z
 
 # Done
 rm -rf $BUILD

--- a/debian.sh
+++ b/debian.sh
@@ -25,7 +25,8 @@ echo '2.0' > debian-binary
 
 # data.tar.xz
 mkdir -p usr/bin
-cp $ORIGIN/xp $ORIGIN/xp.exe $ORIGIN/class-main.php $ORIGIN/web-main.php usr/bin
+cp $ORIGIN/xp.exe usr/bin/xp
+cp $ORIGIN/class-main.php $ORIGIN/web-main.php usr/bin
 $fakeroot tar cfJ data.tar.xz usr/bin/*
 
 # control.tar.gz
@@ -39,7 +40,7 @@ cat <<-EOF > control
 	Maintainer: XP Team <xp-runners@xp-framework.net>
 	Architecture: all
 	Version: ${VERSION}-1
-	Depends: php5-cli, libmono-corlib4.5-cil, libmono-2.0-1
+	Depends: php5-cli, libmono-corlib4.5-cil, libmono-system-core4.5-cil
 	Provides: xp-runners
 	Description: XP Runners
 EOF

--- a/setup.sh.in
+++ b/setup.sh.in
@@ -160,8 +160,6 @@ main() {
   if [ 'Linux' = "$OS" ] ; then OS=$(lsb_release -si) ; fi
   case $OS in
     CYGWIN*)
-      EXE=xp.exe
-
       run 'Cygwin' "uname -a"
       run 'Tar' "commands tar" "/cygwinsetup.exe -P tar -q -n -W"
       run 'Curl' "commands curl wget" "/cygwinsetup.exe -P curl -q -n -W"
@@ -183,8 +181,6 @@ main() {
       ;;
 
     Ubuntu*|Debian*)
-      EXE=xp
-
       run 'Linux' "uname -a"
       run 'Tar' "commands tar" "sudo apt-get -y install tar"
       run 'Curl' "commands curl wget" "sudo apt-get -y install curl"
@@ -198,11 +194,11 @@ main() {
         ver=$($php -r 'echo substr(PHP_VERSION, 0, 3);')
         configure "rt=$ver" "" "[runtime@$ver]" "default=$php"
       fi
+      ln -s xp.exe xp
       ;;
 
-    Darwin*)
-      EXE=xp.exe
-      run 'OS X' "uname -a"
+    *)
+      run 'Un*x' "uname -a"
       run 'Tar' "commands tar"
       run 'Curl' "commands curl wget"
       run '.NET Framework installed' "mono --version" No $CHECKS
@@ -220,31 +216,13 @@ main() {
       echo $(which mono)' $(dirname "$0")/xp.exe "$@"' >> xp
       chmod 755 xp
       ;;
-
-    *)
-      EXE=xp
-
-      run 'Un*x' "uname -a"
-      run 'Tar' "commands tar"
-      run 'Curl' "commands curl wget"
-      run '.NET Framework installed' "mono --version" No $CHECKS
-      run 'PHP runtime available' "php -v" No $CHECKS
-
-      php=$(which php 2>/dev/null || echo No)
-      if [ No = $php ] ; then
-        echo "! No PHP runtime, cannot create xp.ini"
-      else
-        ver=$($php -r 'echo substr(PHP_VERSION, 0, 3);')
-        configure "rt=$ver" "" "[runtime@$ver]" "default=$php"
-      fi
-      ;;
   esac
 
   TARFILE=$(mktemp -u "$temp/tmp.XXXXXXXXXX")
   download https://bintray.com/artifact/download/xp-runners/generic/xp-runners_@VERSION@.tar.gz $TARFILE
 
-  run 'Extract' "tar xvfz $TARFILE $EXE class-main.php web-main.php"
-  run 'Test' "ls -al $(pwd)/$EXE"
+  run 'Extract' "tar xvfz $TARFILE xp.exe class-main.php web-main.php"
+  run 'Test' "ls -al $(pwd)/xp.exe"
 
   echo
   echo "Done, runners installed to $(pwd)"


### PR DESCRIPTION
These are not portable and link to libraries which may not be in place in this versions (but, on the other hand also cannot bundle everything due to licensing / type mismatch problems).

See https://github.com/xp-runners/reference/issues/36#issuecomment-183530767 and #37
