### PR TITLE
Implement "xp list", which shows a list of available subcommands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ install:
   - nuget install xunit.extensions -Version 1.9.2 -OutputDirectory testrunner
 
 script:
+  - sh version.sh
   - cp testrunner/xunit.1.9.2/lib/net20/xunit.dll .
   - cp testrunner/xunit.extensions.1.9.2/lib/net20/xunit.extensions.dll .
   - mcs -r:System.Runtime.Serialization src/xp.runner/*.cs src/xp.runner/*/*.cs -target:exe -out:xp.exe

--- a/src/xp.runner/Command.cs
+++ b/src/xp.runner/Command.cs
@@ -75,7 +75,7 @@ namespace Xp.Runners
         }
 
         /// <summary>Entry point</summary>
-        public int Execute(CommandLine cmd, ConfigSource configuration)
+        public virtual int Execute(CommandLine cmd, ConfigSource configuration)
         {
             Initialize(cmd, configuration);
 

--- a/src/xp.runner/CommandLine.cs
+++ b/src/xp.runner/CommandLine.cs
@@ -68,7 +68,7 @@ namespace Xp.Runners
             var type = Type.GetType("Xp.Runners.Commands." + arg.UpperCaseFirst());
             if (null == type)
             {
-                return new Commands.Plugin(arg);
+                return new Plugin(arg);
             }
             else
             {

--- a/src/xp.runner/EntryPoint.cs
+++ b/src/xp.runner/EntryPoint.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Xp.Runners.Commands
+namespace Xp.Runners
 {
     public class EntryPoint
     {

--- a/src/xp.runner/Plugin.cs
+++ b/src/xp.runner/Plugin.cs
@@ -6,8 +6,9 @@ using System.Runtime.Serialization.Json;
 using Xp.Runners;
 using Xp.Runners.IO;
 using Xp.Runners.Config;
+using Xp.Runners.Commands;
 
-namespace Xp.Runners.Commands
+namespace Xp.Runners
 {
     /// <summary>The plugin command searches for XP commands in Composer's vendor/bin directory</summary>
     public class Plugin : Command

--- a/src/xp.runner/commands/EntryPoint.cs
+++ b/src/xp.runner/commands/EntryPoint.cs
@@ -8,11 +8,12 @@ namespace Xp.Runners.Commands
         const int NAME = 2;
         const int COMMAND = 3;
 
+        private string command;
         private string package;
         private string type;
         private string module;
 
-        /// <summary>Creates a new entry point from a file, e.g. xp.xp-framework.amunittest.test</summary>
+        /// <summary>Creates a new entry point from a file, e.g. xp.xp-framework.unittest.test</summary>
         public EntryPoint(string file)
         {
                 var spec = file.Split('.');
@@ -21,10 +22,14 @@ namespace Xp.Runners.Commands
                     throw new ArgumentException("Malformed input string `" + file + "`");
                 }
 
+                command = spec[spec.Length > COMMAND ? COMMAND : NAME];
                 package = "xp." + spec[NAME];
                 type = package + "." + (spec.Length > COMMAND ? spec[COMMAND].UpperCaseFirst() : string.Empty) + "Runner";
                 module = spec[VENDOR] + "/" + spec[NAME];
         }
+
+        /// <summary>The entry point's name, e.g. test</summary>
+        public string Command { get { return command; } }
 
         /// <summary>The entry point's package name, e.g. xp.unittest</summary>
         public string Package { get { return package; } }

--- a/src/xp.runner/commands/List.cs
+++ b/src/xp.runner/commands/List.cs
@@ -70,6 +70,11 @@ namespace Xp.Runners.Commands
             }
             con.WriteLine();
 
+            foreach (var dir in cmd.Options["modules"])
+            {
+                if (DisplayCommandsIn(con, "\x1b[33;1m>\x1b[0m Module", Paths.Resolve(dir))) con.WriteLine();
+            }
+
             if (DisplayCommandsIn(con, "\x1b[33;1m>\x1b[0m Local", Directory.GetCurrentDirectory()))
             {
                 con.WriteLine();

--- a/src/xp.runner/commands/List.cs
+++ b/src/xp.runner/commands/List.cs
@@ -16,6 +16,7 @@ namespace Xp.Runners.Commands
             return Assembly
                 .GetExecutingAssembly()
                 .GetTypes()
+                .Where(t => t.Namespace == "Xp.Runners.Commands")
                 .Where(t => t.IsSubclassOf(typeof(Command)))
             ;
         }

--- a/src/xp.runner/commands/List.cs
+++ b/src/xp.runner/commands/List.cs
@@ -42,7 +42,7 @@ namespace Xp.Runners.Commands
                         Console.WriteLine("{0} @ {1}:", kind, dir);
                         empty = false;
                     }
-                    Console.WriteLine("> xp {0} (from {1})", entry.Command, entry.Module);
+                    Console.WriteLine("  $ xp {0} (from {1})", entry.Command, entry.Module);
                 }
             }
 
@@ -54,21 +54,26 @@ namespace Xp.Runners.Commands
         {
             var self = Assembly.GetExecutingAssembly();
 
-            Console.WriteLine("Builtin({0}) @ {1}", self.GetName().Version, Paths.Binary());
+            Console.WriteLine("@{0}", Paths.Binary());
+            Console.WriteLine("XP Subcommands");
+            Console.WriteLine("════════════════════════════════════════════════════════════════════════");
+            Console.WriteLine();
+
+            Console.WriteLine("> Builtin({0})", self.GetName().Version);
             foreach (var type in BuiltinsIn(self))
             {
-                Console.WriteLine("> xp {0}", type.Name.ToLower());
+                Console.WriteLine("  $ xp {0}", type.Name.ToLower());
             }
             Console.WriteLine();
 
-            if (DisplayCommandsIn("Local", Directory.GetCurrentDirectory()))
+            if (DisplayCommandsIn("> Local", Directory.GetCurrentDirectory()))
             {
                 Console.WriteLine();
             }
 
             foreach (var dir in ComposerLocations())
             {
-                if (DisplayCommandsIn("Installed", dir)) Console.WriteLine();
+                if (DisplayCommandsIn("> Installed", dir)) Console.WriteLine();
             }
 
             return 0;

--- a/src/xp.runner/commands/List.cs
+++ b/src/xp.runner/commands/List.cs
@@ -1,0 +1,71 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Linq;
+using System.Collections.Generic;
+using Xp.Runners.IO;
+using Xp.Runners.Config;
+
+namespace Xp.Runners.Commands
+{
+    /// <summary>The list command lists available subcommands</summary>
+    public class List : Command
+    {
+        private IEnumerable<Type> Builtins()
+        {
+            return Assembly
+                .GetExecutingAssembly()
+                .GetTypes()
+                .Where(t => t.IsSubclassOf(typeof(Command)))
+            ;
+        }
+
+        private IEnumerable<EntryPoint> ScriptsIn(string dir)
+        {
+            return Directory
+                .GetFiles(dir, "xp.*")
+                .Where(f => !f.EndsWith(".bat"))
+                .Select(f => new EntryPoint(f))
+            ;
+        }
+
+        private bool DisplayCommandsIn(string dir)
+        {
+            var empty = true;
+            var bin = Paths.Compose(dir, "bin");
+            if (Directory.Exists(bin))
+            {
+                foreach (var entry in ScriptsIn(bin))
+                {
+                    if (empty)
+                    {
+                        Console.WriteLine("{0}:", dir);
+                        empty = false;
+                    }
+                    Console.WriteLine("> xp {0} (from {1})", entry.Command, entry.Module);
+                }
+            }
+
+            return !empty;
+        }
+
+        /// <summary>Entry point</summary>
+        public override int Execute(CommandLine cmd, ConfigSource configuration)
+        {
+            Console.WriteLine("Builtin:");
+            foreach (var type in Builtins())
+            {
+                Console.WriteLine("> xp {0}", type.Name.ToLower());
+            }
+            Console.WriteLine();
+
+            foreach (var dir in ComposerLocations())
+            {
+                if (DisplayCommandsIn(dir)) Console.WriteLine();
+            }
+
+            DisplayCommandsIn(".");
+            return 0;
+        }
+    }
+}

--- a/src/xp.runner/commands/List.cs
+++ b/src/xp.runner/commands/List.cs
@@ -60,12 +60,16 @@ namespace Xp.Runners.Commands
             }
             Console.WriteLine();
 
+            if (DisplayCommandsIn(Directory.GetCurrentDirectory()))
+            {
+                Console.WriteLine();
+            }
+
             foreach (var dir in ComposerLocations())
             {
                 if (DisplayCommandsIn(dir)) Console.WriteLine();
             }
 
-            DisplayCommandsIn(".");
             return 0;
         }
     }

--- a/src/xp.runner/commands/List.cs
+++ b/src/xp.runner/commands/List.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Collections.Generic;
 using Xp.Runners.IO;
 using Xp.Runners.Config;
+using Xp.Runners.Exec;
 
 namespace Xp.Runners.Commands
 {
@@ -29,7 +30,7 @@ namespace Xp.Runners.Commands
             ;
         }
 
-        private bool DisplayCommandsIn(string kind, string dir)
+        private bool DisplayCommandsIn(TextWriter con, string kind, string dir)
         {
             var empty = true;
             var bin = Paths.Compose(dir, "bin");
@@ -39,10 +40,11 @@ namespace Xp.Runners.Commands
                 {
                     if (empty)
                     {
-                        Console.WriteLine("{0} @ {1}:", kind, dir);
+                        con.WriteLine("{0} @ {1}", kind, dir);
+                        con.WriteLine();
                         empty = false;
                     }
-                    Console.WriteLine("  $ xp {0} (from {1})", entry.Command, entry.Module);
+                    con.WriteLine("  $ xp {0} (from {1})", entry.Command, entry.Module);
                 }
             }
 
@@ -53,27 +55,29 @@ namespace Xp.Runners.Commands
         public override int Execute(CommandLine cmd, ConfigSource configuration)
         {
             var self = Assembly.GetExecutingAssembly();
+            var con = new ANSISupport(Console.Out);
 
-            Console.WriteLine("@{0}", Paths.Binary());
-            Console.WriteLine("XP Subcommands");
-            Console.WriteLine("════════════════════════════════════════════════════════════════════════");
-            Console.WriteLine();
+            con.WriteLine("\x1b[33m@{0}\x1b[0m", Paths.Binary());
+            con.WriteLine("\x1b[1mXP Subcommands");
+            con.WriteLine("\x1b[36m════════════════════════════════════════════════════════════════════════\x1b[0m");
+            con.WriteLine();
 
-            Console.WriteLine("> Builtin({0})", self.GetName().Version);
+            con.WriteLine("\x1b[33;1m>\x1b[0m Builtin @ {0}", self.GetName().Version);
+            con.WriteLine();
             foreach (var type in BuiltinsIn(self))
             {
-                Console.WriteLine("  $ xp {0}", type.Name.ToLower());
+                con.WriteLine("  $ xp {0}", type.Name.ToLower());
             }
-            Console.WriteLine();
+            con.WriteLine();
 
-            if (DisplayCommandsIn("> Local", Directory.GetCurrentDirectory()))
+            if (DisplayCommandsIn(con, "\x1b[33;1m>\x1b[0m Local", Directory.GetCurrentDirectory()))
             {
-                Console.WriteLine();
+                con.WriteLine();
             }
 
             foreach (var dir in ComposerLocations())
             {
-                if (DisplayCommandsIn("> Installed", dir)) Console.WriteLine();
+                if (DisplayCommandsIn(con, "\x1b[33;1m>\x1b[0m Installed", dir)) con.WriteLine();
             }
 
             return 0;

--- a/src/xp.runner/commands/List.cs
+++ b/src/xp.runner/commands/List.cs
@@ -44,7 +44,7 @@ namespace Xp.Runners.Commands
                         con.WriteLine();
                         empty = false;
                     }
-                    con.WriteLine("  $ xp {0} (from {1})", entry.Command, entry.Module);
+                    con.WriteLine("  $ xp {0} (» \x1b[35;4mfrom {1}\x1b[0m)", entry.Command, entry.Module);
                 }
             }
 

--- a/version.sh
+++ b/version.sh
@@ -11,6 +11,8 @@ else
   BUILD=${TRAVIS_BUILD_NUMBER}
 fi
 
+echo "Version $RELEASE.$BUILD"
+
 rm -f src/xp.runner/AssemblyInfo.cs.patched
 grep -v AssemblyVersion src/xp.runner/AssemblyInfo.cs >> src/xp.runner/AssemblyInfo.cs.patched
 echo '[assembly: AssemblyVersion("'$RELEASE'.'$BUILD'")]' >> src/xp.runner/AssemblyInfo.cs.patched

--- a/version.sh
+++ b/version.sh
@@ -3,12 +3,11 @@
 set -e
 set -u 
 
+BUILD=${TRAVIS_BUILD_NUMBER}
 if [ -z ${TRAVIS_TAG-} ]; then
   RELEASE=$(grep '##' ChangeLog.md | grep -v ???? | head -1 | cut -d ' ' -f 2)
-  BUILD=${TRAVIS_BUILD_NUMBER}
 else
   RELEASE=${TRAVIS_TAG#v*}
-  BUILD=${TRAVIS_BUILD_NUMBER}
 fi
 
 echo "Version $RELEASE.$BUILD"

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -e
+set -u 
+
+if [ -z ${TRAVIS_TAG-} ]; then
+  RELEASE=$(grep '##' ChangeLog.md | grep -v ???? | head -1 | cut -d ' ' -f 2)
+  BUILD=${TRAVIS_BUILD_NUMBER}
+else
+  RELEASE=${TRAVIS_TAG#v*}
+  BUILD=${TRAVIS_BUILD_NUMBER}
+fi
+
+rm -f src/xp.runner/AssemblyInfo.cs.patched
+grep -v AssemblyVersion src/xp.runner/AssemblyInfo.cs >> src/xp.runner/AssemblyInfo.cs.patched
+echo '[assembly: AssemblyVersion("'$RELEASE'.'$BUILD'")]' >> src/xp.runner/AssemblyInfo.cs.patched
+mv src/xp.runner/AssemblyInfo.cs.patched src/xp.runner/AssemblyInfo.cs


### PR DESCRIPTION
Example:

![xp-list-command](https://cloud.githubusercontent.com/assets/696742/13029461/688e5828-d28d-11e5-8d6a-fcc3f48b812a.PNG)

/cc @kiesel I think this can supersede #38
