### PR TITLE
Control configuration file usage

### DIFF
--- a/src/xp.runner.test/CommandLineTest.cs
+++ b/src/xp.runner.test/CommandLineTest.cs
@@ -3,6 +3,7 @@ using Xunit.Extensions;
 using Xp.Runners;
 using Xp.Runners.Commands;
 using Xp.Runners.Exec;
+using Xp.Runners.Config;
 
 namespace Xp.Runners.Test
 {
@@ -187,6 +188,18 @@ namespace Xp.Runners.Test
                 new string[] { "Test", "1", "2", "3" },
                 new CommandLine(new string[] { "run", "Test", "1", "2", "3" }).Arguments
             );
+        }
+
+        [Fact]
+        public void default_configuration()
+        {
+            Assert.IsType<CompositeConfigSource>(new CommandLine(new string[] { }).Configuration);
+        }
+
+        [Fact]
+        public void no_configuration()
+        {
+            Assert.IsType<EnvironmentConfigSource>(new CommandLine(new string[] { "-n" }).Configuration);
         }
     }
 }

--- a/src/xp.runner.test/CommandLineTest.cs
+++ b/src/xp.runner.test/CommandLineTest.cs
@@ -203,7 +203,13 @@ namespace Xp.Runners.Test
         }
 
         [Fact]
-        public void explicit_configuration()
+        public void explicit_configuration_directory()
+        {
+            Assert.IsType<IniConfigSource>(new CommandLine(new string[] { "-c", ".."}).Configuration);
+        }
+
+        [Fact]
+        public void explicit_configuration_file()
         {
             Assert.IsType<IniConfigSource>(new CommandLine(new string[] { "-c", "../xp.ini"}).Configuration);
         }

--- a/src/xp.runner.test/CommandLineTest.cs
+++ b/src/xp.runner.test/CommandLineTest.cs
@@ -201,5 +201,11 @@ namespace Xp.Runners.Test
         {
             Assert.IsType<EnvironmentConfigSource>(new CommandLine(new string[] { "-n" }).Configuration);
         }
+
+        [Fact]
+        public void explicit_configuration()
+        {
+            Assert.IsType<IniConfigSource>(new CommandLine(new string[] { "-c", "../xp.ini"}).Configuration);
+        }
     }
 }

--- a/src/xp.runner/Command.cs
+++ b/src/xp.runner/Command.cs
@@ -95,7 +95,7 @@ namespace Xp.Runners
             }
 
             proc.StartInfo.UseShellExecute = false;
-            proc.StartInfo.FileName = configuration.GetExecutable(runtime) ?? "php";
+            proc.StartInfo.FileName = configuration.GetExecutable(runtime) ?? (runtime ?? "php");
             proc.StartInfo.Arguments = string.Format(
                 "-C -q -d include_path=\".{0}{1}{0}{0}.{0}{2}\" {3} {4} {5}",
                 Paths.Separator,

--- a/src/xp.runner/CommandLine.cs
+++ b/src/xp.runner/CommandLine.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Linq;
 using System.Collections.Generic;
 using Xp.Runners.IO;
@@ -144,7 +145,15 @@ namespace Xp.Runners
                 }
                 else if ("-c".Equals(argv[i]))
                 {
-                    config = new IniConfigSource(new Ini(argv[++i]));
+                    var path = argv[++i];
+                    if (Directory.Exists(path))
+                    {
+                        config = new IniConfigSource(new Ini(Paths.Compose(path, ini)));
+                    }
+                    else
+                    {
+                        config = new IniConfigSource(new Ini(path));
+                    }
                     offset = i + 1;
                 }
                 else if (IsOption(argv[i]))

--- a/src/xp.runner/CommandLine.cs
+++ b/src/xp.runner/CommandLine.cs
@@ -142,6 +142,11 @@ namespace Xp.Runners
                     config = new EnvironmentConfigSource();
                     offset = i + 1;
                 }
+                else if ("-c".Equals(argv[i]))
+                {
+                    config = new IniConfigSource(new Ini(argv[++i]));
+                    offset = i + 1;
+                }
                 else if (IsOption(argv[i]))
                 {
                     throw new ArgumentException("Unknown option `" + argv[i] + "`");

--- a/src/xp.runner/CommandLine.cs
+++ b/src/xp.runner/CommandLine.cs
@@ -169,7 +169,7 @@ namespace Xp.Runners
         /// <summary>Entry point</summary>
         public int Execute()
         {
-            return Command.Execute(this, this.Configuration);
+            return Command.Execute(this, Configuration);
         }
 
         public override string ToString()

--- a/src/xp.runner/CommandLine.cs
+++ b/src/xp.runner/CommandLine.cs
@@ -29,7 +29,7 @@ namespace Xp.Runners
         private Command command;
         private IEnumerable<string> arguments;
         private ExecutionModel executionModel;
-        private string config = ini;
+        private ConfigSource config = null;
 
         /// <summary>Global options</summary>
         public Dictionary<string, List<string>> Options
@@ -61,19 +61,16 @@ namespace Xp.Runners
             get {
                 if (null == config)
                 {
-                    return new EnvironmentConfigSource();
-                }
-                else
-                {
                     var home = Environment.GetEnvironmentVariable("HOME");
-                    return new CompositeConfigSource(
+                    config = new CompositeConfigSource(
                         new EnvironmentConfigSource(),
-                        new IniConfigSource(new Ini(Paths.Compose(".", config))),
-                        null != home ? new IniConfigSource(new Ini(Paths.Compose(home, ".xp", config))) : null,
-                        new IniConfigSource(new Ini(Paths.Compose(Environment.SpecialFolder.LocalApplicationData, "Xp", config))),
-                        new IniConfigSource(new Ini(Paths.Compose(Paths.Binary().DirName(), config)))
+                        new IniConfigSource(new Ini(Paths.Compose(".", ini))),
+                        null != home ? new IniConfigSource(new Ini(Paths.Compose(home, ".xp", ini))) : null,
+                        new IniConfigSource(new Ini(Paths.Compose(Environment.SpecialFolder.LocalApplicationData, "Xp", ini))),
+                        new IniConfigSource(new Ini(Paths.Compose(Paths.Binary().DirName(), ini)))
                     );
                 }
+                return config;
             }
         }
 
@@ -142,7 +139,7 @@ namespace Xp.Runners
                 }
                 else if ("-n".Equals(argv[i]))
                 {
-                    config = null;
+                    config = new EnvironmentConfigSource();
                     offset = i + 1;
                 }
                 else if (IsOption(argv[i]))

--- a/src/xp.runner/Xp.cs
+++ b/src/xp.runner/Xp.cs
@@ -8,26 +8,12 @@ namespace Xp.Runners
     {
         const string ini = "xp.ini";
 
-        /// <summary>Retrieve configuration via xp.ini</summary>
-        private static ConfigSource TheConfiguration()
-        {
-            var home = Environment.GetEnvironmentVariable("HOME");
-            return new CompositeConfigSource(
-                new EnvironmentConfigSource(),
-                new IniConfigSource(new Ini(Paths.Compose(".", ini))),
-                null != home ? new IniConfigSource(new Ini(Paths.Compose(home, ".xp", ini))) : null,
-                new IniConfigSource(new Ini(Paths.Compose(Environment.SpecialFolder.LocalApplicationData, "Xp", ini))),
-                new IniConfigSource(new Ini(Paths.Compose(Paths.Binary().DirName(), ini)))
-            );
-        }
-
         /// <summary>Entry point</summary>
         public static int Main(string[] args)
         {
             try
             {
-                var cmd = new CommandLine(args);
-                return cmd.Execute(TheConfiguration());
+                return new CommandLine(args).Execute();
             }
             catch (NotImplementedException e)
             {

--- a/src/xp.runner/Xp.cs
+++ b/src/xp.runner/Xp.cs
@@ -6,8 +6,6 @@ namespace Xp.Runners
 {
     public class Xp
     {
-        const string ini = "xp.ini";
-
         /// <summary>Entry point</summary>
         public static int Main(string[] args)
         {

--- a/src/xp.runner/config/EnvironmentConfigSource.cs
+++ b/src/xp.runner/config/EnvironmentConfigSource.cs
@@ -48,7 +48,7 @@ namespace Xp.Runners.Config
         /// based on the given runtime version, overwriting the defaults.
         public Dictionary<string, IEnumerable<string>> GetArgs(string runtime)
         {
-            return null;
+            return new Dictionary<string, IEnumerable<string>>();
         }
 
         /// Returns a string representation of this config source


### PR DESCRIPTION
Implements "-n" command line argument which prevents xp.ini files from being loaded. Instead, only the environment variable `USE_XP` is honored, which defines the path to the XP core module (default: COMPOSER_HOME/vendor/xp-framework/core)

/cc @mikey179 
