### PR TITLE
Refactor output handling

### DIFF
--- a/src/xp.runner/commands/List.cs
+++ b/src/xp.runner/commands/List.cs
@@ -1,12 +1,11 @@
 using System;
-using System.Text;
 using System.IO;
 using System.Reflection;
 using System.Linq;
 using System.Collections.Generic;
 using Xp.Runners.IO;
-using Xp.Runners.Config;
 using Xp.Runners.Exec;
+using Xp.Runners.Config;
 
 namespace Xp.Runners.Commands
 {
@@ -72,50 +71,36 @@ namespace Xp.Runners.Commands
         {
             var self = Assembly.GetExecutingAssembly();
 
-            Encoding original = null;
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            using (new Output())
             {
-                original = Console.OutputEncoding;
-                Console.OutputEncoding = System.Text.Encoding.UTF8;
-                if (!Console.IsOutputRedirected)
+                Console.WriteLine("\x1b[33m@{0}\x1b[0m", Paths.Binary());
+                Console.WriteLine("\x1b[1mXP Subcommands");
+                Console.WriteLine("\x1b[36m════════════════════════════════════════════════════════════════════════\x1b[0m");
+                Console.WriteLine();
+
+                Console.WriteLine("\x1b[33;1m>\x1b[0m Builtin @ {0}", self.GetName().Version);
+                Console.WriteLine();
+                foreach (var type in BuiltinsIn(self))
                 {
-                    Console.SetOut(new ANSISupport(Console.Out));
+                    Console.WriteLine("  $ xp {0}", type.Name.ToLower());
+                }
+                Console.WriteLine();
+
+                foreach (var dir in cmd.Options["modules"])
+                {
+                    if (DisplayCommandsIn("\x1b[33;1m>\x1b[0m Module", Paths.Resolve(dir))) Console.WriteLine();
+                }
+
+                if (DisplayCommandsIn("\x1b[33;1m>\x1b[0m Local", Directory.GetCurrentDirectory()))
+                {
+                    Console.WriteLine();
+                }
+
+                foreach (var dir in ComposerLocations())
+                {
+                    if (DisplayCommandsIn("\x1b[33;1m>\x1b[0m Installed", dir)) Console.WriteLine();
                 }
             }
-
-            Console.WriteLine("\x1b[33m@{0}\x1b[0m", Paths.Binary());
-            Console.WriteLine("\x1b[1mXP Subcommands");
-            Console.WriteLine("\x1b[36m════════════════════════════════════════════════════════════════════════\x1b[0m");
-            Console.WriteLine();
-
-            Console.WriteLine("\x1b[33;1m>\x1b[0m Builtin @ {0}", self.GetName().Version);
-            Console.WriteLine();
-            foreach (var type in BuiltinsIn(self))
-            {
-                Console.WriteLine("  $ xp {0}", type.Name.ToLower());
-            }
-            Console.WriteLine();
-
-            foreach (var dir in cmd.Options["modules"])
-            {
-                if (DisplayCommandsIn("\x1b[33;1m>\x1b[0m Module", Paths.Resolve(dir))) Console.WriteLine();
-            }
-
-            if (DisplayCommandsIn("\x1b[33;1m>\x1b[0m Local", Directory.GetCurrentDirectory()))
-            {
-                Console.WriteLine();
-            }
-
-            foreach (var dir in ComposerLocations())
-            {
-                if (DisplayCommandsIn("\x1b[33;1m>\x1b[0m Installed", dir)) Console.WriteLine();
-            }
-
-            if (null != original)
-            {
-                Console.OutputEncoding = original;
-            }
-
             return 0;
         }
     }

--- a/src/xp.runner/exec/Output.cs
+++ b/src/xp.runner/exec/Output.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Text;
 
 namespace Xp.Runners.Exec
@@ -6,6 +7,8 @@ namespace Xp.Runners.Exec
     class Output : IDisposable
     {
         Encoding original = null;
+        TextWriter output = null;
+        TextWriter error = null;
 
         /// <summary>Starts output, enabling ANSI color support when necessary</summary>
         public Output()
@@ -18,7 +21,13 @@ namespace Xp.Runners.Exec
                 Console.OutputEncoding = Encoding.UTF8;
                 if (!Console.IsOutputRedirected)
                 {
+                    output = Console.Out;
                     Console.SetOut(new ANSISupport(Console.Out));
+                }
+                if (!Console.IsErrorRedirected)
+                {
+                    error = Console.Error;
+                    Console.SetError(new ANSISupport(Console.Error));
                 }
             }
         }
@@ -28,6 +37,14 @@ namespace Xp.Runners.Exec
             if (null != original)
             {
                 Console.OutputEncoding = original;
+            }
+            if (null != output)
+            {
+                Console.SetOut(output);
+            }
+            if (null != error)
+            {
+                Console.SetError(error);
             }
         }        
     }

--- a/src/xp.runner/exec/Output.cs
+++ b/src/xp.runner/exec/Output.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Text;
+
+namespace Xp.Runners.Exec
+{
+    class Output : IDisposable
+    {
+        Encoding original = null;
+
+        /// <summary>Starts output, enabling ANSI color support when necessary</summary>
+        public Output()
+        {
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                original = Console.OutputEncoding;
+
+                Console.CancelKeyPress += (sender, args) => Console.OutputEncoding = original;
+                Console.OutputEncoding = Encoding.UTF8;
+                if (!Console.IsOutputRedirected)
+                {
+                    Console.SetOut(new ANSISupport(Console.Out));
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            if (null != original)
+            {
+                Console.OutputEncoding = original;
+            }
+        }        
+    }
+}


### PR DESCRIPTION
Instead of having a "set" and a "reset" block before and after the code relying on this output behaviour (and potentially forgetting a try/finally wrapper around it), make use of the `using` statement
- [x] Inside `list` subcommand
- [x] Inside ExecutionModel class
