### PR TITLE
Pass `XP_*` environment variables

### DIFF
--- a/src/xp.runner/Command.cs
+++ b/src/xp.runner/Command.cs
@@ -114,8 +114,7 @@ namespace Xp.Runners
                 main,
                 string.Join(" ", ArgumentsFor(cmd).Select(args))
             );
-
-            Environment.SetEnvironmentVariable("XP_CMD", string.Format(
+            proc.StartInfo.EnvironmentVariables.Add("XP_CMD", string.Format(
                 "exe={0}&version={1}&model={2}&command={3}",
                 binary,
                 Assembly.GetExecutingAssembly().GetName().Version,

--- a/src/xp.runner/Command.cs
+++ b/src/xp.runner/Command.cs
@@ -114,7 +114,8 @@ namespace Xp.Runners
                 main,
                 string.Join(" ", ArgumentsFor(cmd).Select(args))
             );
-            proc.StartInfo.Environment.Add("XP_CMD", string.Format(
+
+            Environment.SetEnvironmentVariable("XP_CMD", string.Format(
                 "exe={0}&version={1}&model={2}&command={3}",
                 binary,
                 Assembly.GetExecutingAssembly().GetName().Version,

--- a/src/xp.runner/Command.cs
+++ b/src/xp.runner/Command.cs
@@ -114,13 +114,12 @@ namespace Xp.Runners
                 main,
                 string.Join(" ", ArgumentsFor(cmd).Select(args))
             );
-            proc.StartInfo.EnvironmentVariables.Add("XP_CMD", string.Format(
-                "exe={0}&version={1}&model={2}&command={3}",
-                binary,
-                Assembly.GetExecutingAssembly().GetName().Version,
-                cmd.ExecutionModel.Name,
-                GetType().Name.ToLower()
-            ));
+
+            var env = proc.StartInfo.EnvironmentVariables;
+            env.Add("XP_EXE", binary);
+            env.Add("XP_VERSION", Assembly.GetExecutingAssembly().GetName().Version.ToString());
+            env.Add("XP_MODEL", cmd.ExecutionModel.Name);
+            env.Add("XP_COMMAND", GetType().Name.ToLower());
 
             return cmd.ExecutionModel.Execute(proc, encoding);
         }

--- a/src/xp.runner/Command.cs
+++ b/src/xp.runner/Command.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using System.Diagnostics;
 using System.Linq;
 using System.IO;
@@ -70,6 +71,7 @@ namespace Xp.Runners
         {
             Initialize(cmd, configuration);
 
+            var binary = Paths.Binary();
             var proc = new Process();
             var runtime = configuration.GetRuntime();
             var ini = new Dictionary<string, IEnumerable<string>>()
@@ -85,7 +87,7 @@ namespace Xp.Runners
             var main = Paths.TryLocate(use, new string[] { Paths.Compose("tools", MainFor(cmd) + ".php") }).FirstOrDefault();
             if (null == main)
             {
-                main = Paths.Locate(new string[] { Paths.DirName(Paths.Binary()) }, new string[] { MainFor(cmd) + "-main.php" }).First();
+                main = Paths.Locate(new string[] { Paths.DirName(binary) }, new string[] { MainFor(cmd) + "-main.php" }).First();
 
                 // Arguments are encoded in utf-7, which is binary-safe
                 args = Arguments.Encode;
@@ -112,6 +114,13 @@ namespace Xp.Runners
                 main,
                 string.Join(" ", ArgumentsFor(cmd).Select(args))
             );
+            proc.StartInfo.Environment.Add("XP_CMD", string.Format(
+                "exe={0}&version={1}&model={2}&command={3}",
+                binary,
+                Assembly.GetExecutingAssembly().GetName().Version,
+                cmd.ExecutionModel.Name,
+                GetType().Name.ToLower()
+            ));
 
             return cmd.ExecutionModel.Execute(proc, encoding);
         }

--- a/src/xp.runner/exec/ExecutionModel.cs
+++ b/src/xp.runner/exec/ExecutionModel.cs
@@ -10,6 +10,9 @@ namespace Xp.Runners.Exec
     {
         private static PassThrough passThrough = new PassThrough();
 
+        /// <summary>Returns the model's name</summary>
+        public abstract string Name { get; }
+
         /// <summary>Execute the process and return its exitcode</summary>
         public abstract int Execute(Process proc, Encoding encoding);
 

--- a/src/xp.runner/exec/RunOnce.cs
+++ b/src/xp.runner/exec/RunOnce.cs
@@ -5,6 +5,9 @@ namespace Xp.Runners.Exec
 {
     public class RunOnce : ExecutionModel
     {
+        /// <summary>Returns the model's name</summary>
+        public override string Name { get { return "default"; } }
+
         /// <summary>Execute the process and return its exitcode</summary>
         public override int Execute(Process proc, Encoding encoding)
         {

--- a/src/xp.runner/exec/RunWatching.cs
+++ b/src/xp.runner/exec/RunWatching.cs
@@ -18,6 +18,9 @@ namespace Xp.Runners.Exec
             };
         }
 
+        /// <summary>Returns the model's name</summary>
+        public override string Name { get { return "watch"; } }
+
         /// <summary>The path being watched</summary>
         public string Path { get { return watcher.Path; }}
 

--- a/src/xp.runner/exec/Supervise.cs
+++ b/src/xp.runner/exec/Supervise.cs
@@ -11,6 +11,9 @@ namespace Xp.Runners.Exec
         const int WAIT_BEFORE_RESPAWN = 1;
         const int WAIT_FOR_STARTUP = 2;
 
+        /// <summary>Returns the model's name</summary>
+        public override string Name { get { return "supervise"; } }
+
         /// <summary>Execute the process and return its exitcode</summary>
         public override int Execute(Process proc, Encoding encoding)
         {


### PR DESCRIPTION
## What's in it

Contains exe, version, execution model and subcommand as suggested in https://github.com/xp-runners/reference/issues/28#issuecomment-224088746. 
### Example

``` php
[
  XP_EXE => "C:\tools\cygwin\home\Timm\devel\runners\reference\xp.exe"
  XP_VERSION => "7.5.1.17"
  XP_MODEL => "default"
  XP_COMMAND => "write"
]
```
## Usecases

The path to the binary can be used to calculate path to software and config files delivered alongside the XP runners, e.g. certificate bundle like suggested in xp-framework/core#150
