### PR TITLE
Add `tput` drop-in replacement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ script:
   - sh version.sh
   - cp testrunner/xunit.1.9.2/lib/net20/xunit.dll .
   - cp testrunner/xunit.extensions.1.9.2/lib/net20/xunit.extensions.dll .
-  - mcs -r:System.Runtime.Serialization src/xp.runner/*.cs src/xp.runner/*/*.cs -target:exe -out:xp.exe
+  - mcs src/xp.runner/TPut.cs -target:exe -main:Xp.Runners.TPut -out:tput.exe
+  - mcs -r:System.Runtime.Serialization src/xp.runner/*.cs src/xp.runner/*/*.cs -target:exe -main:Xp.Runners.Xp -out:xp.exe
   - mcs -r:System.Runtime.Serialization -r:xunit.dll -r:xunit.extensions.dll src/xp.runner/*.cs src/xp.runner/*/*.cs src/xp.runner.test/*.cs -target:library -out:tests.dll
   - mono ./testrunner/xunit.runners.1.9.2/tools/xunit.console.clr4.exe tests.dll
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
   - sh version.sh
   - cp testrunner/xunit.1.9.2/lib/net20/xunit.dll .
   - cp testrunner/xunit.extensions.1.9.2/lib/net20/xunit.extensions.dll .
-  - mcs src/xp.runner/TPut.cs -target:exe -main:Xp.Runners.TPut -out:tput.exe
+  - mcs src/xp.runner/TPut.cs src/xp.runner/AssemblyInfo.cs -target:exe -main:Xp.Runners.TPut -out:tput.exe
   - mcs -r:System.Runtime.Serialization src/xp.runner/*.cs src/xp.runner/*/*.cs -target:exe -main:Xp.Runners.Xp -out:xp.exe
   - mcs -r:System.Runtime.Serialization -r:xunit.dll -r:xunit.extensions.dll src/xp.runner/*.cs src/xp.runner/*/*.cs src/xp.runner.test/*.cs -target:library -out:tests.dll
   - mono ./testrunner/xunit.runners.1.9.2/tools/xunit.console.clr4.exe tests.dll

--- a/generic.sh
+++ b/generic.sh
@@ -14,7 +14,7 @@ mkdir -p $TARGET
 rm -f $SETUP $BINTRAY
 
 cat setup.sh.in | sed -e "s/@VERSION@/$VERSION/g" > $SETUP
-tar cvfz $ARCHIVE xp.exe class-main.php web-main.php
+tar cvfz $ARCHIVE xp.exe tput.exe class-main.php web-main.php
 
 # Bintray configuration
 date=$(date +%Y-%m-%d)

--- a/setup.sh.in
+++ b/setup.sh.in
@@ -156,6 +156,7 @@ main() {
     exec 3<&1
   fi
 
+  EXTRACT='xp.exe class-main.php web-main.php'
   OS=$(uname)
   if [ 'Linux' = "$OS" ] ; then OS=$(lsb_release -si) ; fi
   case $OS in
@@ -178,6 +179,7 @@ main() {
           "extension_dir=$(cygpath -w $(dirname $php))\\ext" \
           "extension=php_com_dotnet.dll"
       fi
+      EXTRACT="$EXTRACT tput.exe"
       ;;
 
     Ubuntu*|Debian*)
@@ -221,7 +223,7 @@ main() {
   TARFILE=$(mktemp -u "$temp/tmp.XXXXXXXXXX")
   download https://bintray.com/artifact/download/xp-runners/generic/xp-runners_@VERSION@.tar.gz $TARFILE
 
-  run 'Extract' "tar xvfz $TARFILE xp.exe class-main.php web-main.php"
+  run 'Extract' "tar xvfz $TARFILE $EXTRACT"
   run 'Test' "ls -al $(pwd)/xp.exe"
 
   echo

--- a/src/xp.runner/Command.cs
+++ b/src/xp.runner/Command.cs
@@ -70,6 +70,7 @@ namespace Xp.Runners
         {
             Initialize(cmd, configuration);
 
+            var binary = Paths.Binary();
             var proc = new Process();
             var runtime = configuration.GetRuntime();
             var ini = new Dictionary<string, IEnumerable<string>>()
@@ -85,7 +86,7 @@ namespace Xp.Runners
             var main = Paths.TryLocate(use, new string[] { Paths.Compose("tools", MainFor(cmd) + ".php") }).FirstOrDefault();
             if (null == main)
             {
-                main = Paths.Locate(new string[] { Paths.DirName(Paths.Binary()) }, new string[] { MainFor(cmd) + "-main.php" }).First();
+                main = Paths.Locate(new string[] { Paths.DirName(binary) }, new string[] { MainFor(cmd) + "-main.php" }).First();
 
                 // Arguments are encoded in utf-7, which is binary-safe
                 args = Arguments.Encode;
@@ -111,6 +112,12 @@ namespace Xp.Runners
                 string.Join(" ", IniSettings(ini.Concat(configuration.GetArgs(runtime)))),
                 main,
                 string.Join(" ", ArgumentsFor(cmd).Select(args))
+            );
+            proc.StartInfo.EnvironmentVariables["PATH"]= string.Format(
+                "{0}{1}{2}",
+                Environment.GetEnvironmentVariable("PATH"),
+                Path.PathSeparator,
+                Paths.DirName(binary)
             );
 
             return cmd.ExecutionModel.Execute(proc, encoding);

--- a/src/xp.runner/Command.cs
+++ b/src/xp.runner/Command.cs
@@ -114,12 +114,6 @@ namespace Xp.Runners
                 main,
                 string.Join(" ", ArgumentsFor(cmd).Select(args))
             );
-            proc.StartInfo.EnvironmentVariables["PATH"]= string.Format(
-                "{0}{1}{2}",
-                Environment.GetEnvironmentVariable("PATH"),
-                Path.PathSeparator,
-                Paths.DirName(binary)
-            );
 
             var env = proc.StartInfo.EnvironmentVariables;
             env.Add("XP_EXE", binary);

--- a/src/xp.runner/TPut.cs
+++ b/src/xp.runner/TPut.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Reflection;
+using System.Collections.Generic;
+
+namespace Xp.Runners
+{
+    public class TPut
+    {
+        /// <summary>Handles argument handling</summary>
+        private static IEnumerable<string> QueriesPassed(string[] args)
+        {
+            if ("-S" == args[0])
+            {
+                string line;
+                while (null != (line = Console.ReadLine()))
+                {
+                    yield return line.Trim();
+                }
+            }
+            else
+            {
+                yield return args[0];
+            }
+        }
+
+        /// <summary>Drop-in replacement for the `tput` command. Implements
+        /// only three capabilites: lines, cols and bel.</summary>
+        public static int Main(string[] args)
+        {
+            var capabilities = new Dictionary<string, Func<object>>()
+            {
+                { "lines", () => Console.WindowHeight },
+                { "cols", () => Console.WindowWidth },
+                { "bel", () => { Console.Beep(); return null; }}
+            };
+
+            if (0 == args.Length)
+            {
+                Console.Error.WriteLine("usage: tput [-V] [-S] capname");
+                return 1;
+            }
+            else if ("-V" == args[0])
+            {
+                Console.WriteLine(Assembly.GetExecutingAssembly().GetName());
+                return 0;
+            }
+
+            foreach (var query in QueriesPassed(args))
+            {
+                if (capabilities.ContainsKey(query))
+                {
+                    Console.WriteLine(capabilities[query]());
+                }
+                else
+                {
+                    Console.Error.WriteLine("tput: unknown terminfo capability '{0}'", query);
+                    return 1;       
+                }
+            }
+            return 0;
+        }
+    }
+}

--- a/src/xp.runner/TPut.cs
+++ b/src/xp.runner/TPut.cs
@@ -41,7 +41,7 @@ namespace Xp.Runners
             }
             else if ("-V" == args[0])
             {
-                Console.WriteLine(Assembly.GetExecutingAssembly().GetName());
+                Console.WriteLine("xp-runners {0}", Assembly.GetExecutingAssembly().GetName().Version);
                 return 0;
             }
 

--- a/windows.sh
+++ b/windows.sh
@@ -6,6 +6,7 @@ set -u
 . ./init.sh
 
 EXE=$(pwd)/xp.exe
+TPUT=$(pwd)/tput.exe
 TARGET=$(pwd)/target
 MAIN="$(pwd)/class-main.php $(pwd)/web-main.php"
 ZIP=$TARGET/xp-runners_${VERSION}.zip
@@ -15,7 +16,7 @@ mkdir -p target
 rm -f $ZIP $BINTRAY
 
 # Zipfile for Windows
-zip -j $ZIP $EXE $MAIN
+zip -j $ZIP $EXE $TPUT $MAIN
 
 # Bintray configuration
 date=$(date +%Y-%m-%d)


### PR DESCRIPTION
Implements backend for [method to access terminal size](https://github.com/xp-forge/terminal/commit/e05d1de20653c78ab7092bd19844b0ea12a4b351) for environments where there is not `tput` utility.
## Platform overview
- ✅ Cygwin (in /usr/bin, comes with basic install)
- ✅ Linux (in /usr/bin, comes with `ncurses`)
- ✅ Mac OS (in /usr/bin, comes with basic install)
- 🔴 Windows _\- this is where our drop-in would be selected_

See https://github.com/xp-runners/reference/issues/28#issuecomment-226999989
