### PR TITLE
Repeated execution model

### DIFF
--- a/src/xp.runner.test/CommandLineTest.cs
+++ b/src/xp.runner.test/CommandLineTest.cs
@@ -155,7 +155,13 @@ namespace Xp.Runners.Test
         [Fact]
         public void supervise_execution_model()
         {
-            Assert.IsType<Supervise>(new CommandLine(new string[] { "-supervise", "." }).ExecutionModel);
+            Assert.IsType<Supervise>(new CommandLine(new string[] { "-supervise" }).ExecutionModel);
+        }
+
+        [Fact]
+        public void repeat_execution_model()
+        {
+            Assert.IsType<RunRepeatedly>(new CommandLine(new string[] { "-repeat", "every 01:00" }).ExecutionModel);
         }
 
         [Theory]

--- a/src/xp.runner.test/ScheduleTest.cs
+++ b/src/xp.runner.test/ScheduleTest.cs
@@ -1,0 +1,237 @@
+using System;
+using Xunit;
+using Xunit.Extensions;
+using Xp.Runners.Exec;
+
+namespace Xp.Runners.Test
+{
+    public class ScheduleTest
+    {
+        const int PRECISION = 1;
+
+        private TimeSpan runtime = TimeSpan.FromSeconds(30.0);
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("immediately")]
+        public void immediate(string input)
+        {
+            var schedule = new Schedule(input);
+            Assert.Equal(0.0, schedule.Wait.TotalSeconds, PRECISION);
+        }
+
+        [Fact]
+        public void every_five_minutes()
+        {
+            var schedule = new Schedule("every 5:00");
+            Assert.Equal(300.0, schedule.Wait.TotalSeconds, PRECISION);
+        }
+
+        [Fact]
+        public void after_thirty_seconds()
+        {
+            var schedule = new Schedule("after 0:30");
+            Assert.Equal(30.0, schedule.Wait.TotalSeconds, PRECISION);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("forever")]
+        public void forever(string input)
+        {
+            var schedule = new Schedule(input);
+            Assert.Equal(false, schedule.Until(0));
+        }
+
+        [Theory]
+        [InlineData("until 0")]
+        [InlineData("until success")]
+        public void until_success(string input)
+        {
+            var schedule = new Schedule(input);
+            Assert.Equal(true, schedule.Until(0));
+        }
+
+        [Theory]
+        [InlineData("until 255")]
+        [InlineData("until error")]
+        public void until_error(string input)
+        {
+            var schedule = new Schedule(input);
+            Assert.Equal(true, schedule.Until(255));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(255)]
+        public void run(int exitcode)
+        {
+            var schedule = new Schedule("");
+            Assert.Equal(exitcode, schedule.Run(() => exitcode));
+        }
+
+        [Fact]
+        public void run_passes_on_exceptions()
+        {
+            Assert.Throws<InvalidOperationException>(() => new Schedule("").Run(() => {
+                throw new InvalidOperationException("Expected");
+            }));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(255)]
+        public void continues_forever_by_default(int exitcode)
+        {
+            var schedule = new Schedule("");
+            schedule.Run(() => exitcode);
+            Assert.Equal(true, schedule.Continue());
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(255)]
+        public void continues_forever_when_given_forever(int exitcode)
+        {
+            var schedule = new Schedule("forever");
+            schedule.Run(() => exitcode);
+            Assert.Equal(true, schedule.Continue());
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(255)]
+        public void continue_until_success(int exitcode)
+        {
+            var schedule = new Schedule("until success");
+
+            schedule.Run(() => exitcode);
+            Assert.Equal(true, schedule.Continue());
+
+            schedule.Run(() => 0);
+            Assert.Equal(false, schedule.Continue());
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(255)]
+        public void continue_until_error(int exitcode)
+        {
+            var schedule = new Schedule("until error");
+
+            schedule.Run(() => 0);
+            Assert.Equal(true, schedule.Continue());
+
+            schedule.Run(() => exitcode);
+            Assert.Equal(false, schedule.Continue());
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(255)]
+        public void continue_until_codes(int exitcode)
+        {
+            var schedule = new Schedule("until 1|255");
+
+            schedule.Run(() => 0);
+            Assert.Equal(true, schedule.Continue());
+
+            schedule.Run(() => exitcode);
+            Assert.Equal(false, schedule.Continue());
+        }
+
+        [Fact]
+        public void continue_immediately()
+        {
+            var schedule = new Schedule("immediately");
+            schedule.Run(() => 0);
+
+            var delayed = TimeSpan.Zero;
+            schedule.Continue(delay => delayed = delay);
+            Assert.Equal(TimeSpan.Zero, delayed);
+        }
+
+        [Fact]
+        public void continue_after_one_second()
+        {
+            var schedule = new Schedule("after 0:01");
+
+            schedule.Run(() => 0);
+
+            var delayed = TimeSpan.Zero;
+            schedule.Continue(delay => delayed = delay);
+            Assert.Equal(1.0, delayed.TotalSeconds, PRECISION);
+        }
+
+        [Fact]
+        public void delay_running_every()
+        {
+            var schedule = new Schedule("every 1:00");
+            schedule.Run(() => 0, DateTime.Now - runtime);
+
+            var delayed = TimeSpan.Zero;
+            schedule.Continue(delay => delayed = delay);
+            Assert.Equal(30.0, delayed.TotalSeconds, PRECISION);
+        }
+
+        [Fact]
+        public void delay_running_after()
+        {
+            var schedule = new Schedule("after 1:00");
+            schedule.Run(() => 0, DateTime.Now - runtime);
+
+            var delayed = TimeSpan.Zero;
+            schedule.Continue(delay => delayed = delay);
+            Assert.Equal(60.0, delayed.TotalSeconds, PRECISION);
+        }
+
+        [Fact]
+        public void breaks_immediately_when_condition_reached()
+        {
+            var schedule = new Schedule("after 0:03,until success");
+            schedule.Run(() => 0);
+            Assert.Equal(false, schedule.Continue(delay => {
+                throw new InvalidOperationException("Should not be reached!");
+            }));
+        }
+
+        [Theory]
+        [InlineData("everi 1:00")]
+        [InlineData("afters 0:30")]
+        [InlineData("untyl 2")]
+        public void unparseable_spec(string input)
+        {
+            Assert.Throws<ArgumentException>(() => new Schedule(input));
+        }
+
+        [Theory]
+        [InlineData("every")]
+        [InlineData("after")]
+        [InlineData("until")]
+        [InlineData("every 0:30,until")]
+        public void missing_arg_for_spec(string input)
+        {
+            Assert.Throws<ArgumentException>(() => new Schedule(input));
+        }
+
+        [Theory]
+        [InlineData("every ")]
+        [InlineData("every 0")]
+        [InlineData("every a")]
+        [InlineData("every 0:")]
+        [InlineData("every a:")]
+        [InlineData("every :0")]
+        [InlineData("every :a")]
+        [InlineData("every :")]
+        [InlineData("every ::")]
+        [InlineData("every 30:a")]
+        [InlineData("every a:30")]
+        public void unparseable_timespan(string input)
+        {
+            Assert.Throws<FormatException>(() => new Schedule(input));
+        }
+    }
+}

--- a/src/xp.runner.test/ScheduleTest.cs
+++ b/src/xp.runner.test/ScheduleTest.cs
@@ -218,6 +218,16 @@ namespace Xp.Runners.Test
         }
 
         [Fact]
+        public void starts_at_first_time_in_future()
+        {
+            var schedule = new Schedule("at 03:00 06:30 09:15", At(DateTime.Today, "04:00"));
+            var delayed = TimeSpan.Zero;
+
+            schedule.Continue(delay => delayed = delay);
+            Assert.Equal(TimeSpan.FromHours(2.5), delayed);
+        }
+
+        [Fact]
         public void running_at_list_of_times()
         {
             var schedule = new Schedule("at 03:00 06:30 09:15", DateTime.Today);

--- a/src/xp.runner.test/ScheduleTest.cs
+++ b/src/xp.runner.test/ScheduleTest.cs
@@ -23,8 +23,7 @@ namespace Xp.Runners.Test
         [InlineData(255)]
         public void run(int exitcode)
         {
-            var schedule = new Schedule("");
-            Assert.Equal(exitcode, schedule.Run(() => exitcode));
+            Assert.Equal(exitcode, new Schedule("").Run(() => exitcode));
         }
 
         [Fact]
@@ -38,8 +37,7 @@ namespace Xp.Runners.Test
         [Fact]
         public void continues_true_before_first_run()
         {
-            var schedule = new Schedule("");
-            Assert.Equal(true, schedule.Continue());
+            Assert.Equal(true, new Schedule("").Continue());
         }
 
         [Theory]

--- a/src/xp.runner/CommandLine.cs
+++ b/src/xp.runner/CommandLine.cs
@@ -28,6 +28,7 @@ namespace Xp.Runners
             { "-cp!", (self, value) => self.path["classpath"].Add("!" + value) },
             { "-m", (self, value) => self.path["modules"].Add(value) },
             { "-watch", (self, value) => self.executionModel = new RunWatching(value) },
+            { "-repeat", (self, value) => self.executionModel = new RunRepeatedly(value) },
             { "-c", (self, value) => self.config = new CompositeConfigSource(
                 new EnvironmentConfigSource(),
                 new IniConfigSource(new Ini(Directory.Exists(value) ? Paths.Compose(value, ini) : value))

--- a/src/xp.runner/exec/RunRepeatedly.cs
+++ b/src/xp.runner/exec/RunRepeatedly.cs
@@ -1,0 +1,35 @@
+using System.Text;
+using System.Diagnostics;
+
+namespace Xp.Runners.Exec
+{
+    public class RunRepeatedly : ExecutionModel
+    {
+        private Schedule schedule;
+
+        /// <summary>Creates a new repeating runner</summary>
+        public RunRepeatedly(string spec)
+        {
+            schedule = new Schedule(spec);
+        }
+
+        /// <summary>Returns the model's name</summary>
+        public override string Name { get { return "repeat"; } }
+
+        /// <summary>Returns the model's schedule</summary>
+        public Schedule Schedule { get { return schedule; } }
+
+        /// <summary>Execute the process and return its exitcode</summary>
+        public override int Execute(Process proc, Encoding encoding)
+        {
+            int exitcode;
+
+            do
+            {
+                exitcode = schedule.Run(() => Run(proc, encoding));
+            } while (schedule.Continue());
+
+            return exitcode;
+        }
+    }
+}

--- a/src/xp.runner/exec/RunRepeatedly.cs
+++ b/src/xp.runner/exec/RunRepeatedly.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text;
 using System.Diagnostics;
 
@@ -10,7 +11,13 @@ namespace Xp.Runners.Exec
         /// <summary>Creates a new repeating runner</summary>
         public RunRepeatedly(string spec)
         {
-            schedule = new Schedule(spec);
+            try
+            {
+                schedule = new Schedule(spec);
+            } catch (Exception e)
+            {
+                throw new ArgumentException("Repeat: " + e.Message, e);
+            }
         }
 
         /// <summary>Returns the model's name</summary>

--- a/src/xp.runner/exec/RunRepeatedly.cs
+++ b/src/xp.runner/exec/RunRepeatedly.cs
@@ -30,12 +30,12 @@ namespace Xp.Runners.Exec
         /// <summary>Execute the process and return its exitcode</summary>
         public override int Execute(Process proc, Encoding encoding)
         {
-            int exitcode;
+            int exitcode = 0;
 
-            do
+            while (schedule.Continue())
             {
                 exitcode = schedule.Run(() => Run(proc, encoding));
-            } while (schedule.Continue());
+            }
             return exitcode;
         }
     }

--- a/src/xp.runner/exec/RunRepeatedly.cs
+++ b/src/xp.runner/exec/RunRepeatedly.cs
@@ -14,7 +14,8 @@ namespace Xp.Runners.Exec
             try
             {
                 schedule = new Schedule(spec);
-            } catch (Exception e)
+            }
+            catch (Exception e)
             {
                 throw new ArgumentException("Repeat: " + e.Message, e);
             }
@@ -35,7 +36,6 @@ namespace Xp.Runners.Exec
             {
                 exitcode = schedule.Run(() => Run(proc, encoding));
             } while (schedule.Continue());
-
             return exitcode;
         }
     }

--- a/src/xp.runner/exec/Schedule.cs
+++ b/src/xp.runner/exec/Schedule.cs
@@ -62,19 +62,7 @@ namespace Xp.Runners.Exec
                 }
                 else if ("until" == args[0])
                 {
-                    if ("success" == args[1])
-                    {
-                        until = exitcode => (exitcode == 0);
-                    }
-                    else if ("error" == args[1])
-                    {
-                        until = exitcode => (exitcode != 0);
-                    }
-                    else
-                    {
-                        var codes = args[1].Split('|').Select(chunk => Convert.ToInt32(chunk)).ToArray();
-                        until = exitcode => (Array.IndexOf(codes, exitcode) != -1);
-                    }
+                    until = ConditionFrom(args[1]);
                 }
                 else
                 {
@@ -93,6 +81,24 @@ namespace Xp.Runners.Exec
                 case 3: return new TimeSpan(Convert.ToInt32(c[0]), Convert.ToInt32(c[0]), Convert.ToInt32(c[1]));
             }
             throw new FormatException("Cannot parse span `" + input + "'");
+        }
+
+        /// <summary>Parses a stop condition from a string</summary>
+        private Func<int, bool> ConditionFrom(string input)
+        {
+            if ("success" == input)
+            {
+                return exitcode => (exitcode == 0);
+            }
+            else if ("error" == input)
+            {
+                return exitcode => (exitcode != 0);
+            }
+            else
+            {
+                var codes = input.Split('|').Select(chunk => Convert.ToInt32(chunk)).ToArray();
+                return exitcode => (Array.IndexOf(codes, exitcode) != -1);
+            }
         }
 
         /// <summary>Runs a block and calculates continuation and delay</summary>

--- a/src/xp.runner/exec/Schedule.cs
+++ b/src/xp.runner/exec/Schedule.cs
@@ -7,6 +7,8 @@ namespace Xp.Runners.Exec
 {
     public class Schedule
     {
+        const string INTERVAL_FORMAT = "hh\\:mm\\:ss";
+
         private TimeSpan wait;
         private Func<int, bool> until;
 
@@ -109,11 +111,22 @@ namespace Xp.Runners.Exec
         }
 
         /// <summary>Returns whether execution should continue and waits</summary>
-        public bool Continue(Action<TimeSpan> wait)
+        public bool Continue(Action<TimeSpan> waitFor)
         {
             if (condition) return false;
 
-            wait(delay);
+            if (delay < TimeSpan.Zero)
+            {
+                Console.WriteLine(
+                    "Warning: Execution time exceeded scheduled {0} by {1}, running immediately",
+                    wait.ToString(INTERVAL_FORMAT),
+                    delay.Negate().ToString(INTERVAL_FORMAT)
+                );
+            }
+            else
+            {
+                waitFor(delay);
+            }
             return true;
         }
 

--- a/src/xp.runner/exec/Schedule.cs
+++ b/src/xp.runner/exec/Schedule.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Xp.Runners.Exec
+{
+    public class Schedule
+    {
+        private TimeSpan wait;
+        private Func<int, bool> until;
+
+        private TimeSpan delay;
+        private bool condition;
+        private Func<DateTime, TimeSpan> diff;
+
+        /// <summary>Returns how long we need to wait</summary>
+        public TimeSpan Wait { get { return wait; } }
+
+        /// <summary>Returns stop condition</summary>
+        public Func<int, bool> Until { get { return until; } }
+
+        /// <summary>Creates a new schedule from a string</summary>
+        public Schedule(string specs): this(specs.Split(','))
+        {
+        }
+
+        /// <summary>Creates a new schedule from a list of spec</summary>
+        public Schedule(IEnumerable<string> specs)
+        {
+            // Defaults: Run forever without pause
+            until = exitcode => false;
+            wait = TimeSpan.Zero;
+            diff = start => wait;
+
+            foreach (var spec in specs.Where(spec => !String.IsNullOrEmpty(spec)))
+            {
+                var args = spec.Split(' ');
+                if ("forever" == args[0])
+                {
+                    until = exitcode => false;
+                }
+                else if ("immediately" == args[0])
+                {
+                    wait = TimeSpan.Zero;
+                }
+                else if (args.Length < 2)
+                {
+                    throw new ArgumentException("Missing argument for spec `" + spec + "'");
+                }
+                else if ("every" == args[0])
+                {
+                    wait = SpanFrom(args[1]);
+                    diff = start => wait - (DateTime.Now - start);
+                }
+                else if ("after" == args[0])
+                {
+                    wait = SpanFrom(args[1]);
+                    diff = start => wait;
+                }
+                else if ("until" == args[0])
+                {
+                    if ("success" == args[1])
+                    {
+                        until = exitcode => (exitcode == 0);
+                    }
+                    else if ("error" == args[1])
+                    {
+                        until = exitcode => (exitcode != 0);
+                    }
+                    else
+                    {
+                        var codes = args[1].Split('|').Select(chunk => Convert.ToInt32(chunk)).ToArray();
+                        until = exitcode => (Array.IndexOf(codes, exitcode) != -1);
+                    }
+                }
+                else
+                {
+                    throw new ArgumentException("Cannot parse spec `" + spec + "', expecting every, after or until");
+                }
+            }
+        }
+
+        /// <summary>Parses a string into a timespan. Accepts mm:ss and hh:mm:ss</summary>
+        private TimeSpan SpanFrom(string input)
+        {
+            var c = input.Split(':');
+            switch (c.Length)
+            {
+                case 2: return new TimeSpan(0, Convert.ToInt32(c[0]), Convert.ToInt32(c[1]));
+                case 3: return new TimeSpan(Convert.ToInt32(c[0]), Convert.ToInt32(c[0]), Convert.ToInt32(c[1]));
+            }
+            throw new FormatException("Cannot parse span `" + input + "'");
+        }
+
+        /// <summary>Runs a block and calculates continuation and delay</summary>
+        public int Run(Func<int> block, DateTime start)
+        {
+            int exitcode = block();
+            delay = diff(start);
+            condition = until(exitcode);
+            return exitcode;
+        }
+
+        /// <summary>Runs a block and calculates continuation and delay</summary>
+        public int Run(Func<int> block)
+        {
+            return Run(block, DateTime.Now);
+        }
+
+        /// <summary>Returns whether execution should continue and waits</summary>
+        public bool Continue(Action<TimeSpan> wait)
+        {
+            if (condition) return false;
+
+            wait(delay);
+            return true;
+        }
+
+        /// <summary>Returns whether execution should continue</summary>
+        public bool Continue()
+        {
+            return Continue(delay => Thread.Sleep(Convert.ToInt32(delay.TotalMilliseconds)));
+        }
+    }
+}

--- a/src/xp.runner/exec/Schedule.cs
+++ b/src/xp.runner/exec/Schedule.cs
@@ -66,7 +66,10 @@ namespace Xp.Runners.Exec
                 }
                 else
                 {
-                    throw new ArgumentException("Cannot parse definition `" + definition + "', expecting every, after or until");
+                    throw new ArgumentException(string.Format(
+                        "Cannot parse definition `{0}', expecting one of `forever', `immediately', `every', `after' or `until'",
+                        args[0]
+                    ));
                 }
             }
         }

--- a/src/xp.runner/exec/Schedule.cs
+++ b/src/xp.runner/exec/Schedule.cs
@@ -118,7 +118,7 @@ namespace Xp.Runners.Exec
             if (delay < TimeSpan.Zero)
             {
                 Console.WriteLine(
-                    "Warning: Execution time exceeded scheduled {0} by {1}, running immediately",
+                    "\x1b[33;1mWarning: Execution time exceeded scheduled {0} by {1}, running immediately\x1b[0m",
                     wait.ToString(INTERVAL_FORMAT),
                     delay.Negate().ToString(INTERVAL_FORMAT)
                 );

--- a/src/xp.runner/exec/Schedule.cs
+++ b/src/xp.runner/exec/Schedule.cs
@@ -23,21 +23,21 @@ namespace Xp.Runners.Exec
         public Func<int, bool> Until { get { return until; } }
 
         /// <summary>Creates a new schedule from a string</summary>
-        public Schedule(string specs): this(specs.Split(','))
+        public Schedule(string schedule): this(schedule.Split(','))
         {
         }
 
-        /// <summary>Creates a new schedule from a list of spec</summary>
-        public Schedule(IEnumerable<string> specs)
+        /// <summary>Creates a new schedule from a list of definitions</summary>
+        public Schedule(IEnumerable<string> schedule)
         {
             // Defaults: Run forever without pause
             until = exitcode => false;
             wait = TimeSpan.Zero;
             diff = start => wait;
 
-            foreach (var spec in specs.Where(spec => !String.IsNullOrEmpty(spec)))
+            foreach (var definition in schedule.Where(definition => !String.IsNullOrEmpty(definition)))
             {
-                var args = spec.Split(' ');
+                var args = definition.Split(' ');
                 if ("forever" == args[0])
                 {
                     until = exitcode => false;
@@ -48,7 +48,7 @@ namespace Xp.Runners.Exec
                 }
                 else if (args.Length < 2)
                 {
-                    throw new ArgumentException("Missing argument for spec `" + spec + "'");
+                    throw new ArgumentException("Missing argument for definition `" + definition + "'");
                 }
                 else if ("every" == args[0])
                 {
@@ -66,7 +66,7 @@ namespace Xp.Runners.Exec
                 }
                 else
                 {
-                    throw new ArgumentException("Cannot parse spec `" + spec + "', expecting every, after or until");
+                    throw new ArgumentException("Cannot parse definition `" + definition + "', expecting every, after or until");
                 }
             }
         }

--- a/src/xp.runner/exec/Schedule.cs
+++ b/src/xp.runner/exec/Schedule.cs
@@ -68,6 +68,17 @@ namespace Xp.Runners.Exec
                     var times = args.Skip(1).Select(TimeFrom).ToArray();
                     var offset = 0;
 
+                    // Find first element in the future, start there. If all times are in the past,
+                    // start at beginning (which will add a day).
+                    while (now.TimeOfDay > times[offset])
+                    {
+                        if (++offset >= times.Length)
+                        {
+                            offset= 0;
+                            break;
+                        }
+                    }
+
                     // Delay until next
                     next = (start, end) => {
                         wait = times[offset];


### PR DESCRIPTION
This pull request implements xp-framework/rfc#314
### Repititions
- [x] `immediately`
- [x] `every <spec>`
- [x] `after <spec>`
- [x] `at <time> [<time> [...]]`
### Stop conditions
- [x] `forever`
- [x] `until success`
- [x] `until error`
- [x] `until <code> [|<code> [|...]]`
