### PR TITLE
Reinstate XAR command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ script:
   - cp testrunner/xunit.1.9.2/lib/net20/xunit.dll .
   - cp testrunner/xunit.extensions.1.9.2/lib/net20/xunit.extensions.dll .
   - mcs src/xp.runner/TPut.cs src/xp.runner/AssemblyInfo.cs -target:exe -main:Xp.Runners.TPut -out:tput.exe
+  - mcs -r:System.Runtime.Serialization src/xp.runner/*.cs src/xp.runner/*/*.cs -target:exe -main:Xp.Runners.Xar -out:xar.exe
   - mcs -r:System.Runtime.Serialization src/xp.runner/*.cs src/xp.runner/*/*.cs -target:exe -main:Xp.Runners.Xp -out:xp.exe
   - mcs -r:System.Runtime.Serialization -r:xunit.dll -r:xunit.extensions.dll src/xp.runner/*.cs src/xp.runner/*/*.cs src/xp.runner.test/*.cs -target:library -out:tests.dll
   - mono ./testrunner/xunit.runners.1.9.2/tools/xunit.console.clr4.exe tests.dll

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ XP Runners change log
 
 ## 7.9.0 / 2017-06-03
 
+* Reinstated xar command, implementing issue #67 - @thekid
 * Refactored entry point code to no longer use `xp::stringOf()`, which
   will be deprecated in XP9. See xp-framework/rfc#324
   (@thekid)

--- a/debian.sh
+++ b/debian.sh
@@ -25,8 +25,13 @@ echo '2.0' > debian-binary
 
 # data.tar.xz
 mkdir -p usr/bin
+
 printf '#!/bin/sh\nexec /usr/bin/mono /usr/bin/xp.exe "$@"\n' > usr/bin/xp
 chmod 755 usr/bin/xp
+
+printf '#!/bin/sh\nexec /usr/bin/mono /usr/bin/xp.exe ar "$@"\n' > usr/bin/xar
+chmod 755 usr/bin/xar
+
 cp $ORIGIN/xp.exe usr/bin/xp.exe
 cp $ORIGIN/class-main.php $ORIGIN/web-main.php usr/bin
 $fakeroot tar cfJ data.tar.xz usr/bin/*

--- a/generic.sh
+++ b/generic.sh
@@ -15,7 +15,7 @@ mkdir -p $TARGET
 rm -f $SETUP $BINTRAY
 
 cat setup.sh.in | sed -e "s/@VERSION@/$VERSION/g" > $SETUP
-tar cvfz $ARCHIVE xp.exe tput.exe class-main.php web-main.php
+tar cvfz $ARCHIVE xp.exe xar.exe tput.exe class-main.php web-main.php
 
 # Slim runner
 (cat xp-run.sh.in | sed -e "s/@VERSION@/$VERSION/g" ; cat class-main.php ) > $SLIM

--- a/setup.sh.in
+++ b/setup.sh.in
@@ -179,7 +179,7 @@ main() {
           "extension_dir=$(cygpath -w $(dirname $php))\\ext" \
           "extension=php_com_dotnet.dll"
       fi
-      EXTRACT="$EXTRACT tput.exe"
+      EXTRACT="$EXTRACT xar.exe tput.exe"
       ;;
 
     Ubuntu*|Debian*)
@@ -200,6 +200,10 @@ main() {
       echo '#!/bin/sh' > xp
       echo 'exec '$(which mono)' $(dirname "$0")/xp.exe "$@"' >> xp
       chmod 755 xp
+
+      echo '#!/bin/sh' > xar
+      echo 'exec '$(which mono)' $(dirname "$0")/xp.exe ar "$@"' >> xar
+      chmod 755 xar
       ;;
 
     *)
@@ -220,6 +224,10 @@ main() {
       echo '#!/bin/sh' > xp
       echo 'exec '$(which mono)' $(dirname "$0")/xp.exe "$@"' >> xp
       chmod 755 xp
+
+      echo '#!/bin/sh' > xar
+      echo 'exec '$(which mono)' $(dirname "$0")/xp.exe ar "$@"' >> xar
+      chmod 755 xar
       ;;
   esac
 

--- a/src/xp.runner/Xar.cs
+++ b/src/xp.runner/Xar.cs
@@ -1,0 +1,16 @@
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Xp.Runners
+{
+    public class Xar
+    {
+        private static string[] command = new string[] {"ar"};
+
+        /// <summary>Entry point</summary>
+        public static int Main(string[] args)
+        {
+            return Xp.Main(command.Concat(args).ToArray());
+        }
+    }
+}

--- a/windows.sh
+++ b/windows.sh
@@ -7,6 +7,7 @@ set -u
 
 EXE=$(pwd)/xp.exe
 TPUT=$(pwd)/tput.exe
+XAR=$(pwd)/xar.exe
 TARGET=$(pwd)/target
 MAIN="$(pwd)/class-main.php $(pwd)/web-main.php"
 ZIP=$TARGET/xp-runners_${VERSION}.zip
@@ -16,7 +17,7 @@ mkdir -p target
 rm -f $ZIP $BINTRAY
 
 # Zipfile for Windows
-zip -j $ZIP $EXE $TPUT $MAIN
+zip -j $ZIP $EXE $XAR $TPUT $MAIN
 
 # Bintray configuration
 date=$(date +%Y-%m-%d)


### PR DESCRIPTION
Implements #67 by:

* Creating a `xar.exe` on Windows systems
* Creating a wrapper script `/usr/bin/xar` which calls `xp.exe ar "$@"` on Un*x / MacOS