### PR TITLE
Signalling socket

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,12 @@ XP Runners change log
 
 ## ?.?.? / ????-??-??
 
+## 8.0.0 / ????-??-??
+
+* Implemented pull request #70: Signalling socket. This allows graceful
+  shutdown when being run inside `xp -supervise`.
+  (@thekid)
+
 ## 7.9.2 / 2017-07-02 
 
 * Fixed issue #69: Hash marks (#) comments causing exceptions - adjusted

--- a/src/xp.runner/exec/Supervise.cs
+++ b/src/xp.runner/exec/Supervise.cs
@@ -12,7 +12,7 @@ namespace Xp.Runners.Exec
     {
         const int WAIT_BEFORE_RESPAWN = 1;
         const int WAIT_FOR_STARTUP = 2;
-        private static byte[] QUIT = new byte[] { 81, 85, 73, 84 };
+        private static byte[] QUIT = new byte[] { 81, 85, 73, 84, 13, 10 };  // "QUIT\r\n"
 
         /// <summary>Returns the model's name</summary>
         public override string Name { get { return "supervise"; } }

--- a/src/xp.runner/exec/Supervise.cs
+++ b/src/xp.runner/exec/Supervise.cs
@@ -20,7 +20,7 @@ namespace Xp.Runners.Exec
         /// <summary>Execute the process and return its exitcode</summary>
         public override int Execute(Process proc, Encoding encoding)
         {
-            Action shutdown = () => proc.Kill();
+            Action shutdown = proc.Kill;
 
             // Read from STDIN
             var cancel = new ManualResetEvent(false);
@@ -28,7 +28,8 @@ namespace Xp.Runners.Exec
             var stdin = Console.OpenStandardInput();
             var result = stdin.BeginRead(buffer, 0, buffer.Length, ar => cancel.Set(), null);
 
-            // Set up signalling socket
+            // Set up signalling socket. Once PHP connects to it, rewrite shutdown action
+            // to a graceful variant: Sending a quit message to the signalling socket.
             var sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             sock.Bind(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 0));
             sock.Listen(1);

--- a/src/xp.runner/exec/Supervise.cs
+++ b/src/xp.runner/exec/Supervise.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Net;
+using System.Net.Sockets;
 using System.Text;
 using System.Diagnostics;
 using System.Threading;
@@ -10,6 +12,7 @@ namespace Xp.Runners.Exec
     {
         const int WAIT_BEFORE_RESPAWN = 1;
         const int WAIT_FOR_STARTUP = 2;
+        private static byte[] QUIT = new byte[] { 81, 85, 73, 84 };
 
         /// <summary>Returns the model's name</summary>
         public override string Name { get { return "supervise"; } }
@@ -17,11 +20,33 @@ namespace Xp.Runners.Exec
         /// <summary>Execute the process and return its exitcode</summary>
         public override int Execute(Process proc, Encoding encoding)
         {
+            Action shutdown = () => proc.Kill();
+
+            // Read from STDIN
             var cancel = new ManualResetEvent(false);
             var buffer = new byte[256];
             var stdin = Console.OpenStandardInput();
             var result = stdin.BeginRead(buffer, 0, buffer.Length, ar => cancel.Set(), null);
 
+            // Set up signalling socket
+            var sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            sock.Bind(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 0));
+            sock.Listen(1);
+            sock.BeginAccept(
+              ar => {
+                  var listener = ((Socket)ar.AsyncState).EndAccept(ar);
+                  shutdown = () =>
+                  {
+                      listener.Send(QUIT);
+                      listener.Shutdown(SocketShutdown.Both);
+                      listener.Close();
+                      proc.WaitForExit();
+                  };
+              },
+              sock
+            );
+
+            proc.StartInfo.EnvironmentVariables["XP_SIGNAL"] = ((IPEndPoint)sock.LocalEndPoint).Port.ToString();
             proc.StartInfo.RedirectStandardInput = true;
             proc.EnableRaisingEvents = true;
             proc.Exited += (sender, args) => cancel.Set();
@@ -38,9 +63,9 @@ namespace Xp.Runners.Exec
 
                     if (result.IsCompleted)
                     {
-                        Console.WriteLine("==> Shut down");
+                        Console.Write("==> Shut down ");
                         stdin.EndRead(result);
-                        proc.Kill();
+                        shutdown();
                         return 0;
                     }
                     else

--- a/src/xp.runner/exec/Supervise.cs
+++ b/src/xp.runner/exec/Supervise.cs
@@ -64,7 +64,7 @@ namespace Xp.Runners.Exec
 
                     if (result.IsCompleted)
                     {
-                        Console.Write("==> Shut down ");
+                        Console.Write("> Shut down ");
                         stdin.EndRead(result);
                         shutdown();
                         return 0;
@@ -97,6 +97,7 @@ namespace Xp.Runners.Exec
 
             // Either via user-interactive shutdown or via runtime exiting itself
             stdin.Close();
+            sock.Close();
             return code;
         }
     }


### PR DESCRIPTION
This pull request opens a signalling socket inside the `supervise` execution model. PHP can decide to `select()` on it and shut down cleanly as soon as data becomes available on it, instead of being killed.

This works around Windows PHP not being able to `select` on file handles; otherwise we could simply throw `STDIN` into the *read* array. See https://stackoverflow.com/questions/12499523/using-sys-stdin-in-select-select-on-windows

See also issue #47