### PR TITLE
Use script namespace to calculate user-namespaced class path

### DIFF
--- a/src/xp.runner/Command.cs
+++ b/src/xp.runner/Command.cs
@@ -27,6 +27,12 @@ namespace Xp.Runners
             }
         }
 
+        /// <summary>Use path. Overwrite in subclasses if necessary!</summary>
+        protected virtual IEnumerable<string> UseFor(CommandLine cmd)
+        {
+            return null;
+        }
+
         /// <summary>Main script, e.g. "class". Overwrite in subclasses if necessary!</summary>
         protected virtual string MainFor(CommandLine cmd)
         {
@@ -80,7 +86,7 @@ namespace Xp.Runners
                 { "date.timezone", new string[] { TimeZoneInfo.Local.Olson() ?? Environment.GetEnvironmentVariable("TZ") ?? "UTC" } },
                 { "extension", configuration.GetExtensions(runtime) }
             };
-            var use = configuration.GetUse() ?? UseComposer();
+            var use = UseFor(cmd) ?? configuration.GetUse() ?? UseComposer();
 
             Encoding encoding;
             Func<string, string> args;

--- a/src/xp.runner/commands/Run.cs
+++ b/src/xp.runner/commands/Run.cs
@@ -13,8 +13,8 @@ namespace Xp.Runners.Commands
     {
         private static Regex ns = new Regex("\\<\\?php namespace (?<ns>[^;]+);");
 
-        /// <summary>Additional class path entries to load</summary>
-        protected override IEnumerable<string> ClassPathFor(CommandLine cmd)
+        /// <summary>Use path</summary>
+        protected override IEnumerable<string> UseFor(CommandLine cmd)
         {
             var execute = cmd.Arguments.FirstOrDefault();
 
@@ -25,16 +25,17 @@ namespace Xp.Runners.Commands
                     var matches = ns.Matches(sr.ReadLine());
                     if (matches.Count > 0)
                     {
-                        var autoload = Paths.Compose(Paths.UserDir("xp"), matches[0].Groups["ns"].Value, "vendor", "autoload.php");
-                        if (File.Exists(autoload))
+                        var use = Paths.Compose(Paths.UserDir("xp"), matches[0].Groups["ns"].Value, "vendor", "xp-framework", "core");
+                        if (Directory.Exists(use))
                         {
-                            return base.ClassPathFor(cmd).Append(autoload);
+                            return new string[] { use };
                         }
                     }
                 }
             }
 
-            return base.ClassPathFor(cmd);
+            // Use default "use" path
+            return null;
         }
    }
 }

--- a/src/xp.runner/commands/Run.cs
+++ b/src/xp.runner/commands/Run.cs
@@ -1,9 +1,72 @@
 using Xp.Runners;
+using Xp.Runners.IO;
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Xp.Runners.Commands
 {
     /// <summary>run $class [$arg0 [$arg1 [...]]]</summary>
     public class Run : Command
     {
-    }
+        private static Regex ns = new Regex("\\<\\?php namespace (?<ns>[^;]+);");
+
+        /// <summary>Returns whether the environment indicates this system conforms to
+        /// https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html</summary>
+        private static bool UseXDG()
+        {
+            foreach (string variable in Environment.GetEnvironmentVariables().Keys)
+            {
+                if (variable.StartsWith("XDG_")) return true;
+            }
+            return false;
+        }
+
+        /// <summary>Returns the user-specific config directory. Respects $HOME, XDG-compliant
+        /// systems and falls back to using %APPDATA%</summary>
+        private string UserDir()
+        {
+            if (UseXDG())
+            {
+                return Paths.Compose(
+                    Environment.GetEnvironmentVariable("XDG_CONFIG_HOME") ?? Paths.Compose(Paths.Home(), ".config"),
+                    "xp"
+                );
+            }
+
+            var home = Environment.GetEnvironmentVariable("HOME");
+            if (!String.IsNullOrEmpty(home))
+            {
+                return Paths.Compose(home, ".xp");
+            }
+
+            return Paths.Compose(Environment.SpecialFolder.ApplicationData, "XP");
+        }
+
+        /// <summary>Additional class path entries to load</summary>
+        protected override IEnumerable<string> ClassPathFor(CommandLine cmd)
+        {
+            var execute = cmd.Arguments.FirstOrDefault();
+
+            // Extract PHP namespace from first line of file, except for classes
+            if (File.Exists(execute) && !execute.Contains(".class.php"))
+            {
+                using (StreamReader sr = new StreamReader(execute)) {
+                    var matches = ns.Matches(sr.ReadLine());
+                    if (matches.Count > 0)
+                    {
+                        var autoload = Paths.Compose(UserDir(), matches[0].Groups["ns"].Value, "vendor", "autoload.php");
+                        if (File.Exists(autoload))
+                        {
+                            return base.ClassPathFor(cmd).Append(autoload);
+                        }
+                    }
+                }
+            }
+
+            return base.ClassPathFor(cmd);
+        }
+   }
 }

--- a/src/xp.runner/commands/Run.cs
+++ b/src/xp.runner/commands/Run.cs
@@ -1,10 +1,9 @@
-using Xp.Runners;
-using Xp.Runners.IO;
-using System;
-using System.IO;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Xp.Runners.IO;
+using Xp.Runners;
 
 namespace Xp.Runners.Commands
 {

--- a/src/xp.runner/commands/Run.cs
+++ b/src/xp.runner/commands/Run.cs
@@ -13,38 +13,6 @@ namespace Xp.Runners.Commands
     {
         private static Regex ns = new Regex("\\<\\?php namespace (?<ns>[^;]+);");
 
-        /// <summary>Returns whether the environment indicates this system conforms to
-        /// https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html</summary>
-        private static bool UseXDG()
-        {
-            foreach (string variable in Environment.GetEnvironmentVariables().Keys)
-            {
-                if (variable.StartsWith("XDG_")) return true;
-            }
-            return false;
-        }
-
-        /// <summary>Returns the user-specific config directory. Respects $HOME, XDG-compliant
-        /// systems and falls back to using %APPDATA%</summary>
-        private string UserDir()
-        {
-            if (UseXDG())
-            {
-                return Paths.Compose(
-                    Environment.GetEnvironmentVariable("XDG_CONFIG_HOME") ?? Paths.Compose(Paths.Home(), ".config"),
-                    "xp"
-                );
-            }
-
-            var home = Environment.GetEnvironmentVariable("HOME");
-            if (!String.IsNullOrEmpty(home))
-            {
-                return Paths.Compose(home, ".xp");
-            }
-
-            return Paths.Compose(Environment.SpecialFolder.ApplicationData, "XP");
-        }
-
         /// <summary>Additional class path entries to load</summary>
         protected override IEnumerable<string> ClassPathFor(CommandLine cmd)
         {
@@ -57,7 +25,7 @@ namespace Xp.Runners.Commands
                     var matches = ns.Matches(sr.ReadLine());
                     if (matches.Count > 0)
                     {
-                        var autoload = Paths.Compose(UserDir(), matches[0].Groups["ns"].Value, "vendor", "autoload.php");
+                        var autoload = Paths.Compose(Paths.UserDir("xp"), matches[0].Groups["ns"].Value, "vendor", "autoload.php");
                         if (File.Exists(autoload))
                         {
                             return base.ClassPathFor(cmd).Append(autoload);

--- a/src/xp.runner/io/ComposerLocations.cs
+++ b/src/xp.runner/io/ComposerLocations.cs
@@ -9,26 +9,18 @@ namespace Xp.Runners.IO
     {
         public const string VENDOR = "vendor";
 
-        /// <summary>Returns whether the environment indicates this system conforms to
-        /// https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html</summary>
-        private static bool UseXDG()
-        {
-            foreach (string variable in Environment.GetEnvironmentVariables().Keys)
-            {
-                if (variable.StartsWith("XDG_")) return true;
-            }
-            return false;
-        }
-
         /// <summary>Returns well-known locations of Composer directories</summary>
         public static IEnumerable<string> For(PlatformID platform, Func<string, bool> exists)
         {
             yield return Paths.Compose(".", VENDOR);
 
+            // Don't use Paths.UserDir() here as the order of preference is a bit different:
+            // 1. If ~/.composer exists, it is preferred over the XDG config dir
+            // 2. We will always use $APPDATA/Composer on Windows, ignoring $HOME
             if (PlatformID.Unix == platform)
             {
                 var composer = Paths.Compose(Paths.Home(), ".composer");
-                if (!exists(composer) && UseXDG())
+                if (!exists(composer) && Paths.UseXDG())
                 {
                     yield return Paths.Compose(
                         Environment.GetEnvironmentVariable("XDG_CONFIG_HOME") ?? Paths.Compose(Paths.Home(), ".config"),

--- a/src/xp.runner/io/Paths.cs
+++ b/src/xp.runner/io/Paths.cs
@@ -96,7 +96,6 @@ namespace Xp.Runners.IO
             {
                 return Compose(home, "." + name);
             }
-
         }
 
         /// <summary>Resolve a path. If the path is actually a shell link (.lnk file), this link's target path is used</summary>


### PR DESCRIPTION
This pull request implements xp-framework/rfc#332 and calculates a user-namespaced class path by looking at the script's first line:

```php
<?php namespace test;  // will add $USER/test/vendor/xp-framework/core to modules
```

The user directory is calculated equivalent to the `lang.Environment::userDir()` specification:

1. `$XDG_CONFIG_HOME/xp` on [XDG-compliant](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) systems
2. `$HOME/.xp` if a environment variable named *HOME* is set (Un\*x, Cygwin)
3. `%APPDATA%\Xp` on Windows
