### PR TITLE
Check composer.json for subcommands

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,9 @@ XP Runners change log
 
 ## 8.2.0 / 2020-11-23
 
-* Merged PR #78: Check `composer.json` for subcommands - @thekid
+* Merged PR #78: Check `composer.json` for subcommands using the scripts
+  section, see https://getcomposer.org/doc/articles/scripts.md
+  @thekid
 
 ## 8.1.7 / 2019-07-29
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,10 @@ XP Runners change log
 
 ## ?.?.? / ????-??-??
 
+## 8.2.0 / 2020-11-23
+
+* Merged PR #78: Check `composer.json` for subcommands - @thekid
+
 ## 8.1.7 / 2019-07-29
 
 * Fixed `include(): xp\xar::stream_set_option is not implemented!` warnings

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Getting started
 To install the XP runners, you can choose between the generic installer:
 
 ```sh
-$ curl -sSL https://dl.bintray.com/xp-runners/generic/setup-8.1.6.sh | sh
+$ curl -sSL https://dl.bintray.com/xp-runners/generic/setup-8.2.0.sh | sh
 # ...
 ```
 
@@ -32,8 +32,8 @@ $ composer global require xp-framework/core
 # ...
 
 $ xp version
-XP 10.0.0-dev { PHP/7.3.7 & Zend/3.3.7 } @ Windows NT SLATE 10.0 build 18362 (Windows 10) AMD64
-Copyright (c) 2001-2019 the XP group
+XP 10.4.0 { PHP/7.4.12 & Zend/3.4.0 } @ Windows NT SURFACE 10.0 build 19042 (Windows 10) AMD64
+Copyright (c) 2001-2020 the XP group
 FileSystemCL<$APPDATA/Composer/vendor/xp-framework/core/src/main/php>
 FileSystemCL<$APPDATA/Composer/vendor/xp-framework/core/src/test/php>
 FileSystemCL<$APPDATA/Composer/vendor/xp-framework/core/src/main/resources>

--- a/src/xp.runner.test/CommandLineTest.cs
+++ b/src/xp.runner.test/CommandLineTest.cs
@@ -88,11 +88,17 @@ namespace Xp.Runners.Test
             Assert.Equal("web", (new CommandLine(new string[] { "web" }).Command as Plugin).Name);
         }
 
-        [Fact]
-        public void script_via_composer_file()
+        [Theory]
+        [InlineData("xp web org.example.web.App")]
+        [InlineData("xp 'web' org.example.web.App")]
+        [InlineData("xp web 'org.example.web.App'")]
+        [InlineData("xp web 'org.example.web.App")]
+        public void script_via_composer_file(string script)
         {
-            var composer = ComposerFile(@"{""scripts"":{""serve"":""xp web org.example.web.App""}}");
-            Assert.Equal("web", (new CommandLine(new string[] { "serve" }, composer).Command as Plugin).Name);
+            var composer = ComposerFile(@"{""scripts"":{""serve"":""%s""}}".Replace("%s", script));
+            var fixture = new CommandLine(new string[] { "serve" }, composer);
+            Assert.Equal("web", (fixture.Command as Plugin).Name);
+            Assert.Equal(new string[] { "org.example.web.App" }, fixture.Arguments);
         }
 
         [Fact]

--- a/src/xp.runner.test/CommandLineTest.cs
+++ b/src/xp.runner.test/CommandLineTest.cs
@@ -96,6 +96,16 @@ namespace Xp.Runners.Test
         }
 
         [Fact]
+        public void script_via_composer_file_with_arguments()
+        {
+            var composer = ComposerFile(@"{""scripts"":{""serve"":""xp web org.example.web.App""}}");
+            Assert.Equal(
+                new string[] { "org.example.web.App", "dev" },
+                new CommandLine(new string[] { "serve", "dev" }, composer).Arguments
+            );
+        }
+
+        [Fact]
         public void classpath_initially_empty()
         {
             Assert.Equal(new string[] { }, new CommandLine(new string[] { }).Path["classpath"].ToArray());

--- a/src/xp.runner.test/CommandLineTest.cs
+++ b/src/xp.runner.test/CommandLineTest.cs
@@ -4,6 +4,7 @@ using Xp.Runners;
 using Xp.Runners.Commands;
 using Xp.Runners.Exec;
 using Xp.Runners.Config;
+using System.IO;
 
 namespace Xp.Runners.Test
 {
@@ -72,6 +73,26 @@ namespace Xp.Runners.Test
         public void ar(string arg)
         {
             Assert.IsType<Ar>(new CommandLine(new string[] { arg }).Command);
+        }
+
+        [Fact]
+        public void plugin()
+        {
+            Assert.IsType<Plugin>(new CommandLine(new string[] { "web" }).Command);
+        }
+
+        [Fact]
+        public void script_via_composer_file()
+        {
+            File.WriteAllText(ComposerFile.NAME, @"{""scripts"":{""serve"":""xp web org.example.web.App""}}");
+            try
+            {
+                Assert.Equal("web", (new CommandLine(new string[] { "serve" }).Command as Plugin).Name);
+            }
+            finally
+            {
+                File.Delete(ComposerFile.NAME);
+            }
         }
 
         [Fact]

--- a/src/xp.runner.test/CommandLineTest.cs
+++ b/src/xp.runner.test/CommandLineTest.cs
@@ -89,14 +89,13 @@ namespace Xp.Runners.Test
         }
 
         [Theory]
-        [InlineData("xp web org.example.web.App")]
-        [InlineData("xp 'web' org.example.web.App")]
-        [InlineData("xp web 'org.example.web.App'")]
-        [InlineData("xp web 'org.example.web.App")]
-        public void script_via_composer_file(string script)
+        [InlineData(@"{""scripts"":{""serve"":""xp web org.example.web.App""}}")]
+        [InlineData(@"{""scripts"":{""serve"":""xp 'web' org.example.web.App""}}")]
+        [InlineData(@"{""scripts"":{""serve"":""xp web 'org.example.web.App'""}}")]
+        [InlineData(@"{""scripts"":{""serve"":""xp web 'org.example.web.App""}}")]
+        public void script_via_composer_file(string source)
         {
-            var composer = ComposerFile(@"{""scripts"":{""serve"":""%s""}}".Replace("%s", script));
-            var fixture = new CommandLine(new string[] { "serve" }, composer);
+            var fixture = new CommandLine(new string[] { "serve" }, ComposerFile(source));
             Assert.Equal("web", (fixture.Command as Plugin).Name);
             Assert.Equal(new string[] { "org.example.web.App" }, fixture.Arguments);
         }
@@ -109,6 +108,16 @@ namespace Xp.Runners.Test
                 new string[] { "org.example.web.App", "dev" },
                 new CommandLine(new string[] { "serve", "dev" }, composer).Arguments
             );
+        }
+
+        [Theory]
+        [InlineData(@"{}")]
+        [InlineData(@"{""scripts"":{}}")]
+        [InlineData(@"{""scripts"":{""serve"":""xp web org.example.web.App""}}")]
+        [InlineData(@"{""scripts"":{""test"":""phpunit""}}")]
+        public void plugin_when_script_is_not_in_composer_file(string source)
+        {
+            Assert.Equal("test", (new CommandLine(new string[] { "test" }, ComposerFile(source)).Command as Plugin).Name);
         }
 
         [Fact]

--- a/src/xp.runner.test/CommandLineTest.cs
+++ b/src/xp.runner.test/CommandLineTest.cs
@@ -5,11 +5,18 @@ using Xp.Runners.Commands;
 using Xp.Runners.Exec;
 using Xp.Runners.Config;
 using System.IO;
+using System.Text;
 
 namespace Xp.Runners.Test
 {
     public class CommandLineTest
     {
+        /// <summary>Helper to create a ComposerFile from a string</summary>
+        private ComposerFile ComposerFile(string declaration)
+        {
+            return new ComposerFile(new MemoryStream(Encoding.UTF8.GetBytes(declaration.Trim())));
+        }
+
         [Fact]
         public void default_command_is_help()
         {
@@ -78,21 +85,14 @@ namespace Xp.Runners.Test
         [Fact]
         public void plugin()
         {
-            Assert.IsType<Plugin>(new CommandLine(new string[] { "web" }).Command);
+            Assert.Equal("web", (new CommandLine(new string[] { "web" }).Command as Plugin).Name);
         }
 
         [Fact]
         public void script_via_composer_file()
         {
-            File.WriteAllText(ComposerFile.NAME, @"{""scripts"":{""serve"":""xp web org.example.web.App""}}");
-            try
-            {
-                Assert.Equal("web", (new CommandLine(new string[] { "serve" }).Command as Plugin).Name);
-            }
-            finally
-            {
-                File.Delete(ComposerFile.NAME);
-            }
+            var composer = ComposerFile(@"{""scripts"":{""serve"":""xp web org.example.web.App""}}");
+            Assert.Equal("web", (new CommandLine(new string[] { "serve" }, composer).Command as Plugin).Name);
         }
 
         [Fact]

--- a/src/xp.runner.test/CommandLineTest.cs
+++ b/src/xp.runner.test/CommandLineTest.cs
@@ -115,6 +115,7 @@ namespace Xp.Runners.Test
         [InlineData(@"{""scripts"":{}}")]
         [InlineData(@"{""scripts"":{""serve"":""xp web org.example.web.App""}}")]
         [InlineData(@"{""scripts"":{""test"":""phpunit""}}")]
+        [InlineData(@"{""scripts"":{""test"":""xprop""}}")]
         public void plugin_when_script_is_not_in_composer_file(string source)
         {
             Assert.Equal("test", (new CommandLine(new string[] { "test" }, ComposerFile(source)).Command as Plugin).Name);

--- a/src/xp.runner/AssemblyInfo.cs
+++ b/src/xp.runner/AssemblyInfo.cs
@@ -6,6 +6,6 @@ using System.Runtime.Versioning;
 [assembly: AssemblyCompany("XP-Framework Team")]
 [assembly: AssemblyProduct("XP Runners")]
 [assembly: AssemblyTitle("XP Runner")]
-[assembly: AssemblyCopyright("Copyright XP-Framework Team 2001-2019")]
-[assembly: AssemblyVersion("8.1.6.1405")]
+[assembly: AssemblyCopyright("Copyright XP-Framework Team 2001-2020")]
+[assembly: AssemblyVersion("8.2.0.0102")]
 [assembly: TargetFramework(".NETFramework,Version=v5.0")]

--- a/src/xp.runner/CommandLine.cs
+++ b/src/xp.runner/CommandLine.cs
@@ -171,6 +171,7 @@ namespace Xp.Runners
                         executionModel = null;
                         config = null;
                         Parse(composer.Definitions.Scripts[name].Split(new char[] { ' ' }), 1, ComposerFile.Empty);
+                        arguments = arguments.Concat(argv.Skip(offset));
                         return;
                     }
 

--- a/src/xp.runner/CommandLine.cs
+++ b/src/xp.runner/CommandLine.cs
@@ -100,7 +100,13 @@ namespace Xp.Runners
         /// <summary>Creates the commandline representation from argv</summary>
         public CommandLine(string[] argv)
         {
-            Parse(argv, 0);
+            Parse(argv, 0, ComposerFile.Empty);
+        }
+
+        /// <summary>Creates the commandline representation from argv and a composer file</summary>
+        public CommandLine(string[] argv, ComposerFile composer)
+        {
+            Parse(argv, 0, composer);
         }
 
         /// <summary>Determines if a command line arg is an option</summary>
@@ -116,7 +122,7 @@ namespace Xp.Runners
         }
 
         /// <summary>Parses command line</summary>
-        private void Parse(string[] argv, int start)
+        private void Parse(string[] argv, int start, ComposerFile composer)
         {
             var offset = 0;
             for (var i = start; i < argv.Length; i++)
@@ -159,20 +165,13 @@ namespace Xp.Runners
                     }
 
                     // Check composer.json for scripts
-                    if (File.Exists(ComposerFile.NAME))
+                    if (composer.Definitions.Scripts.ContainsKey(name))
                     {
-                        using (var composer = new ComposerFile(ComposerFile.NAME))
-                        {
-                            if (composer.Definitions.Scripts.ContainsKey(name))
-                            {
-                                command = null;
-                                arguments = new string[] { };
-                                executionModel = null;
-                                config = null;
-                                Parse(composer.Definitions.Scripts[name].Split(new char[] { ' ' }), 1);
-                                return;
-                            }
-                        }
+                        command = null;
+                        executionModel = null;
+                        config = null;
+                        Parse(composer.Definitions.Scripts[name].Split(new char[] { ' ' }), 1, ComposerFile.Empty);
+                        return;
                     }
 
                     // Otherwise, it's a plugin defined via `bin/xp.{org}.{slug}.{name}`

--- a/src/xp.runner/CommandLine.cs
+++ b/src/xp.runner/CommandLine.cs
@@ -100,13 +100,13 @@ namespace Xp.Runners
         /// <summary>Creates the commandline representation from argv</summary>
         public CommandLine(string[] argv)
         {
-            Parse(argv, 0, ComposerFile.Empty);
+            Parse(argv, ComposerFile.Empty);
         }
 
         /// <summary>Creates the commandline representation from argv and a composer file</summary>
         public CommandLine(string[] argv, ComposerFile composer)
         {
-            Parse(argv, 0, composer);
+            Parse(argv, composer);
         }
 
         /// <summary>Determines if a command line arg is an option</summary>
@@ -154,10 +154,10 @@ namespace Xp.Runners
         }
 
         /// <summary>Parses command line</summary>
-        private void Parse(string[] argv, int start, ComposerFile composer)
+        private void Parse(string[] argv, ComposerFile composer)
         {
             var offset = 0;
-            for (var i = start; i < argv.Length; i++)
+            for (var i = 0; i < argv.Length; i++)
             {
                 if (aliases.ContainsKey(argv[i]))
                 {
@@ -202,7 +202,7 @@ namespace Xp.Runners
                         command = null;
                         executionModel = null;
                         config = null;
-                        Parse(ArgsOf(composer.Definitions.Scripts[name]).ToArray(), 1, ComposerFile.Empty);
+                        Parse(ArgsOf(composer.Definitions.Scripts[name]).Skip(1).ToArray(), ComposerFile.Empty);
                         arguments = arguments.Concat(argv.Skip(offset));
                         return;
                     }

--- a/src/xp.runner/CommandLine.cs
+++ b/src/xp.runner/CommandLine.cs
@@ -121,6 +121,38 @@ namespace Xp.Runners
             return arg.All(c => char.IsLower(c) || '-' == c);
         }
 
+        /// <summary>Parses arguments from a given string</summary>
+        private IEnumerable<string> ArgsOf(string arg)
+        {
+            int index, quote;
+            var offset = 0;
+            do
+            {
+                if ('"' == arg[offset] || '\'' == arg[offset])
+                {
+                    index = arg.IndexOf(arg[offset], offset + 1);
+                    quote = 1;
+                }
+                else
+                {
+                    index = arg.IndexOf(' ', offset);
+                    quote = 0;
+                }
+
+                if (-1 == index)
+                {
+                    yield return arg.Substring(offset + quote);
+                    break;
+                }
+                else
+                {
+                    yield return arg.Substring(offset + quote, index - offset - quote);
+                    offset = index + 1 + quote;
+                }
+            }
+            while (offset < arg.Length);
+        }
+
         /// <summary>Parses command line</summary>
         private void Parse(string[] argv, int start, ComposerFile composer)
         {
@@ -170,7 +202,7 @@ namespace Xp.Runners
                         command = null;
                         executionModel = null;
                         config = null;
-                        Parse(composer.Definitions.Scripts[name].Split(new char[] { ' ' }), 1, ComposerFile.Empty);
+                        Parse(ArgsOf(composer.Definitions.Scripts[name]).ToArray(), 1, ComposerFile.Empty);
                         arguments = arguments.Concat(argv.Skip(offset));
                         return;
                     }

--- a/src/xp.runner/CommandLine.cs
+++ b/src/xp.runner/CommandLine.cs
@@ -197,7 +197,7 @@ namespace Xp.Runners
                     }
 
                     // Check composer.json for scripts
-                    if (composer.Definitions.Scripts.ContainsKey(name))
+                    if (composer.Definitions.Scripts.ContainsKey(name) && composer.Definitions.Scripts[name].StartsWith("xp "))
                     {
                         command = null;
                         executionModel = null;

--- a/src/xp.runner/Plugin.cs
+++ b/src/xp.runner/Plugin.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Collections.Generic;
-using System.Runtime.Serialization.Json;
 using Xp.Runners;
 using Xp.Runners.IO;
 using Xp.Runners.Config;
@@ -16,6 +15,8 @@ namespace Xp.Runners
         private string name;
         private EntryPoint entry;
         private IEnumerable<string> modules;
+
+        public string Name { get { return name; }}
 
         public EntryPoint EntryPoint { get { return entry; }}
 
@@ -32,6 +33,7 @@ namespace Xp.Runners
         public override void Initialize(CommandLine cmd, ConfigSource configuration)
         {
             base.Initialize(cmd, configuration);
+
             foreach (var dir in cmd.Path["modules"].Concat(new string[] { "." }))
             {
                 if (null == (entry = FindEntryPoint(dir, name))) continue;
@@ -39,7 +41,6 @@ namespace Xp.Runners
                 modules = new string[] { };
                 return;
             }
-
             foreach (var dir in ComposerLocations())
             {
                 if (null == (entry = FindEntryPoint(dir, name))) continue;

--- a/src/xp.runner/Xp.cs
+++ b/src/xp.runner/Xp.cs
@@ -1,5 +1,7 @@
 using System;
+using System.IO;
 using Xp.Runners.IO;
+using Xp.Runners.Commands;
 using Xp.Runners.Config;
 
 namespace Xp.Runners
@@ -11,7 +13,14 @@ namespace Xp.Runners
         {
             try
             {
-                return new CommandLine(args).Execute();
+                if (File.Exists(ComposerFile.NAME))
+                {
+                    return new CommandLine(args, new ComposerFile(ComposerFile.NAME)).Execute();
+                }
+                else
+                {
+                    return new CommandLine(args).Execute();
+                }
             }
             catch (ArgumentException e)
             {

--- a/src/xp.runner/commands/Composer.cs
+++ b/src/xp.runner/commands/Composer.cs
@@ -9,5 +9,7 @@ namespace Xp.Runners.Commands
         public string Name { get; set; }
 
         public Dictionary<string, string> Require { get; set; }
+
+        public Dictionary<string, string> Scripts { get; set; }
     }
 }

--- a/src/xp.runner/commands/ComposerFile.cs
+++ b/src/xp.runner/commands/ComposerFile.cs
@@ -74,6 +74,10 @@ namespace Xp.Runners.Commands
                             .Where(pair => pair.Key.StartsWith(@"root\require\"))
                             .ToDictionary(value => value.Key.Substring(@"root\require\".Length), value => value.First())
                         ;
+                        definitions.Scripts = lookup
+                            .Where(pair => pair.Key.StartsWith(@"root\scripts\"))
+                            .ToDictionary(value => value.Key.Substring(@"root\scripts\".Length), value => value.First())
+                        ;
                     }
                 }
                 return definitions;

--- a/src/xp.runner/commands/ComposerFile.cs
+++ b/src/xp.runner/commands/ComposerFile.cs
@@ -16,6 +16,25 @@ namespace Xp.Runners.Commands
         private Composer definitions;
         private XmlDictionaryReader input;
 
+        /// <summary>Creates an empty composer file</summary>
+        public static ComposerFile Empty
+        {
+            get
+            {
+                var empty = new Composer();
+                empty.Name = "";
+                empty.Require = new Dictionary<string, string>();
+                empty.Scripts = new Dictionary<string, string>();
+                return new ComposerFile(empty);
+            }
+        }
+
+        /// <summary>Creates a composer file with given definitions</summary>
+        public ComposerFile(Composer definitions)
+        {
+            this.definitions = definitions;
+        }
+
         /// <summary>Creates an instance from a given stream</summary>
         public ComposerFile(Stream input)
         {


### PR DESCRIPTION
Implements idea layed out in #77

## Example

Using [Composer scripts](https://getcomposer.org/doc/articles/scripts.md) inside composer.json:

```javascript
{
  "name": "thekid/cas",
  "require": {
    "xp-framework/core": "^10.0",
    // Shortened for brevity...
  },
  "scripts": {
    "serve": "xp -supervise web -c src/main/etc/dev de.thekid.cas.App"
  }
}
```

To run the web application, simply use `xp serve`.