### PR TITLE
Add vendor/autoload.php to class path if a composer file is existant

### DIFF
--- a/src/xp.runner.test/CommandLineTest.cs
+++ b/src/xp.runner.test/CommandLineTest.cs
@@ -4,6 +4,7 @@ using Xp.Runners;
 using Xp.Runners.Commands;
 using Xp.Runners.Exec;
 using Xp.Runners.Config;
+using Xp.Runners.IO;
 using System.IO;
 using System.Text;
 using System.Linq;
@@ -184,6 +185,18 @@ namespace Xp.Runners.Test
                 new string[] { "?src/main/php" },
                 new CommandLine(new string[] { "-cp?", "src/main/php" }).Path["classpath"].ToArray()
             );
+        }
+
+        [Fact]
+        public void passes_autoload_via_class_path_if_composer_file_present()
+        {
+            using (var file = new TemporaryFile("composer.json").Empty())
+            {
+                Assert.Equal(
+                    new string[] { "?" + Paths.Compose(Paths.DirName(file.Path), "vendor", "autoload.php") },
+                    new CommandLine(new string[] { }, new ComposerFile(file.Path)).Path["classpath"].ToArray()
+                );
+            }
         }
 
         [Fact]

--- a/src/xp.runner.test/CommandLineTest.cs
+++ b/src/xp.runner.test/CommandLineTest.cs
@@ -144,7 +144,7 @@ namespace Xp.Runners.Test
         [InlineData(@"{""scripts"":{")]
         public void invalid_composer_file(string source)
         {
-            Assert.Throws<FileFormatException>(() => new CommandLine(new string[] { "serve" }, ComposerFile(source)));
+            Assert.Throws<FileFormatException>(() => new CommandLine(new string[] { }, ComposerFile(source)));
         }
 
         [Fact]

--- a/src/xp.runner.test/CommandLineTest.cs
+++ b/src/xp.runner.test/CommandLineTest.cs
@@ -187,13 +187,15 @@ namespace Xp.Runners.Test
             );
         }
 
-        [Fact]
-        public void passes_autoload_via_class_path_if_composer_file_present()
+        [Theory]
+        [InlineData(@"{}", "vendor")]
+        [InlineData(@"{""config"":{""vendor-dir"":""bundle""}}", "bundle")]
+        public void passes_autoload_via_class_path_if_composer_file_present(string composer, string vendor)
         {
-            using (var file = new TemporaryFile("composer.json").Empty())
+            using (var file = new TemporaryFile("composer.json").Containing(composer))
             {
                 Assert.Equal(
-                    new string[] { "?" + Paths.Compose(Paths.DirName(file.Path), "vendor", "autoload.php") },
+                    new string[] { "?" + Paths.Compose(Paths.DirName(file.Path), vendor, "autoload.php") },
                     new CommandLine(new string[] { }, new ComposerFile(file.Path)).Path["classpath"].ToArray()
                 );
             }

--- a/src/xp.runner.test/CommandLineTest.cs
+++ b/src/xp.runner.test/CommandLineTest.cs
@@ -189,6 +189,7 @@ namespace Xp.Runners.Test
 
         [Theory]
         [InlineData(@"{}", "vendor")]
+        [InlineData(@"{""config"":{}}", "vendor")]
         [InlineData(@"{""config"":{""vendor-dir"":""bundle""}}", "bundle")]
         public void passes_autoload_via_class_path_if_composer_file_present(string composer, string vendor)
         {

--- a/src/xp.runner/CommandLine.cs
+++ b/src/xp.runner/CommandLine.cs
@@ -109,6 +109,7 @@ namespace Xp.Runners
             using (composer)
             {
                 Parse(argv, composer);
+                path["classpath"].Add("?" + Paths.Compose(Paths.DirName(composer.SourceUri), "vendor", "autoload.php"));
             }
         }
 

--- a/src/xp.runner/CommandLine.cs
+++ b/src/xp.runner/CommandLine.cs
@@ -117,7 +117,7 @@ namespace Xp.Runners
                     ));
                     Parse(argv, composer);
                 }
-                catch (FormatException e)
+                catch (FileFormatException e)
                 {
                     Console.Error.WriteLine("Warning: {0}", e.Message);
                     Parse(argv, ComposerFile.Empty);

--- a/src/xp.runner/CommandLine.cs
+++ b/src/xp.runner/CommandLine.cs
@@ -108,20 +108,12 @@ namespace Xp.Runners
         {
             using (composer)
             {
-                try
-                {
-                    path["classpath"].Add(
-                        "?" + Paths.Compose(Paths.DirName(composer.SourceUri),
-                        composer.Definitions.VendorDir,
-                        "autoload.php"
-                    ));
-                    Parse(argv, composer);
-                }
-                catch (FileFormatException e)
-                {
-                    Console.Error.WriteLine("Warning: {0}", e.Message);
-                    Parse(argv, ComposerFile.Empty);
-                }
+                path["classpath"].Add(
+                    "?" + Paths.Compose(Paths.DirName(composer.SourceUri),
+                    composer.Definitions.VendorDir,
+                    "autoload.php"
+                ));
+                Parse(argv, composer);
             }
         }
 

--- a/src/xp.runner/Xp.cs
+++ b/src/xp.runner/Xp.cs
@@ -17,12 +17,17 @@ namespace Xp.Runners
                 {
                     if (File.Exists(ComposerFile.NAME))
                     {
-                        return new CommandLine(args, new ComposerFile(ComposerFile.NAME)).Execute();
+                        try
+                        {
+                            return new CommandLine(args, new ComposerFile(ComposerFile.NAME)).Execute();
+                        }
+                        catch (FileFormatException e)
+                        {
+                            Console.Error.WriteLine("Warning: {0}", e.Message);
+                        }
                     }
-                    else
-                    {
-                        return new CommandLine(args).Execute();
-                    }
+
+                    return new CommandLine(args).Execute();
                 }
                 catch (CannotExecute e)
                 {

--- a/src/xp.runner/Xp.cs
+++ b/src/xp.runner/Xp.cs
@@ -24,6 +24,7 @@ namespace Xp.Runners
                         catch (FileFormatException e)
                         {
                             Console.Error.WriteLine("Warning: {0}", e.Message);
+                            // Fall through, continuing as if no composer file was present
                         }
                     }
 

--- a/src/xp.runner/commands/Composer.cs
+++ b/src/xp.runner/commands/Composer.cs
@@ -8,6 +8,8 @@ namespace Xp.Runners.Commands
     {
         public string Name { get; set; }
 
+        public string VendorDir { get; set; }
+
         public Dictionary<string, string> Require { get; set; }
 
         public Dictionary<string, string> Scripts { get; set; }

--- a/src/xp.runner/commands/ComposerFile.cs
+++ b/src/xp.runner/commands/ComposerFile.cs
@@ -95,6 +95,7 @@ namespace Xp.Runners.Commands
 
                             definitions = new Composer();
                             definitions.Name = lookup[@"root\name"].FirstOrDefault();
+                            definitions.VendorDir = lookup[@"root\config\vendor-dir"].FirstOrDefault() ?? "vendor";
                             definitions.Require = lookup
                                 .Where(pair => pair.Key.StartsWith(@"root\require\"))
                                 .ToDictionary(value => value.Key.Substring(@"root\require\".Length), value => value.First())

--- a/src/xp.runner/commands/ComposerFile.cs
+++ b/src/xp.runner/commands/ComposerFile.cs
@@ -5,6 +5,7 @@ using System.Xml;
 using System.Runtime.Serialization.Json;
 using System.Collections.Generic;
 using Xp.Runners;
+using Xp.Runners.IO;
 
 namespace Xp.Runners.Commands
 {
@@ -107,7 +108,7 @@ namespace Xp.Runners.Commands
                         }
                         catch (XmlException e)
                         {
-                            throw new FormatException(string.Format("Parsing {0} failed: {1}", SourceUri, e.Message), e);
+                            throw new FileFormatException(string.Format("Parsing {0} failed: {1}", SourceUri, e.Message), e);
                         }
                     }
                 }

--- a/src/xp.runner/io/FileFormatException.cs
+++ b/src/xp.runner/io/FileFormatException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Xp.Runners.IO
+{
+    public class FileFormatException : FormatException 
+    {
+        public FileFormatException(string message, Exception inner) : base(message, inner)
+        {
+        }
+    }
+}


### PR DESCRIPTION
This pull request automatically adds `?[vendor-dir]/autoload.php` to the class path if a `composer.json` file is present, respecting https://getcomposer.org/doc/06-config.md#vendor-dir. This makes it optional to include a *class.pth* file containing this string in the project directory.

**Note**: If there is a syntax error in `composer.json`, running `xp` will yield a warning on standard error:

```bash
$ echo "#" > composer.json 

$ xp 
Warning: Parsing composer.json failed: Unerwartetes Zeichen '#'.
# ...
```

This requires a subtle change to unique the files passed to `require`, see xp-runners/main@1edd6323476ae1d27449ab7b865e9cef3e9a639e

