### PR TITLE
Environment variables

### DIFF
--- a/src/xp.runner.test/CommandLineTest.cs
+++ b/src/xp.runner.test/CommandLineTest.cs
@@ -226,6 +226,50 @@ namespace Xp.Runners.Test
         }
 
         [Fact]
+        public void env_initially_empty()
+        {
+            Assert.Equal(new Ini[] { }, new CommandLine(new string[] { }).EnvFiles.ToArray());
+        }
+
+        [Fact]
+        public void one_environment_entry()
+        {
+            Assert.Equal(
+                new Ini[] { new Ini(".env") },
+                new CommandLine(new string[] { "-env", ".env" }).EnvFiles.ToArray()
+            );
+        }
+
+        [Fact]
+        public void multiple_environment_entries()
+        {
+            Assert.Equal(
+                new Ini[] { new Ini(".env"), new Ini(".env.prod") },
+                new CommandLine(new string[] { "-env", ".env", "-env", ".env.prod" }).EnvFiles.ToArray()
+            );
+        }
+
+        [Fact]
+        public void try_adding_env_file()
+        {
+            var fixture = new CommandLine(new string[] { });
+
+            using (var file = new TemporaryFile(".env.test").Containing("KEY=value"))
+            {
+                fixture.TryAddEnv(file.Path);
+                Assert.Equal(new Ini[] { new Ini(file.Path) }, fixture.EnvFiles.ToArray());
+            }
+        }
+
+        [Fact]
+        public void try_adding_nonexistant_env_file()
+        {
+            var fixture = new CommandLine(new string[] { });
+            fixture.TryAddEnv(".env.nonexistant");
+            Assert.Equal(new Ini[] { }, fixture.EnvFiles.ToArray());
+        }
+
+        [Fact]
         public void runonce_is_default_execution_model()
         {
             Assert.IsType<RunOnce>(new CommandLine(new string[] { }).ExecutionModel);

--- a/src/xp.runner.test/CommandLineTest.cs
+++ b/src/xp.runner.test/CommandLineTest.cs
@@ -252,10 +252,9 @@ namespace Xp.Runners.Test
         [Fact]
         public void try_adding_env_file()
         {
-            var fixture = new CommandLine(new string[] { });
-
             using (var file = new TemporaryFile(".env.test").Containing("KEY=value"))
             {
+                var fixture = new CommandLine(new string[] { });
                 fixture.TryAddEnv(file.Path);
                 Assert.Equal(new Ini[] { new Ini(file.Path) }, fixture.EnvFiles.ToArray());
             }
@@ -276,10 +275,9 @@ namespace Xp.Runners.Test
         [InlineData("KEY=value\nCOLOR=green", "KEY=value,COLOR=green")]
         public void environment_variables(string contents, string expected)
         {
-            var fixture = new CommandLine(new string[] { });
-
             using (var file = new TemporaryFile(".env.test").Containing(contents))
             {
+                var fixture = new CommandLine(new string[] { });
                 fixture.TryAddEnv(file.Path);
                 Assert.Equal(expected, string.Join(",", fixture.EnvVariables.Select(e => e.Key + "=" + e.Value)));
             }

--- a/src/xp.runner.test/CommandLineTest.cs
+++ b/src/xp.runner.test/CommandLineTest.cs
@@ -275,6 +275,7 @@ namespace Xp.Runners.Test
         [InlineData("KEY=value", new string[] { "KEY=value" })]
         [InlineData("KEY=value\nCOLOR=green", new string[] { "KEY=value", "COLOR=green" })]
         [InlineData("KEY=\\$value", new string[] { "KEY=$value" })]
+        [InlineData("PROMPT=$PS1", new string[] { "PROMPT=user@host$" })]
         [InlineData("AUTH=$USER:$PASS", new string[] { "AUTH=testing:" })]
         [InlineData("PASS=secret\nAUTH=$USER:$PASS", new string[] { "PASS=secret", "AUTH=testing:secret" })]
         [InlineData("PASS=secret\nAUTH=${USER}:${PASS}", new string[] { "PASS=secret", "AUTH=testing:secret" })]
@@ -285,6 +286,7 @@ namespace Xp.Runners.Test
             {
                 var env = new StringDictionary();
                 env.Add("USER", "testing");
+                env.Add("PS1", "user@host$");
 
                 var fixture = new CommandLine(new string[] { });
                 fixture.TryAddEnv(file.Path);

--- a/src/xp.runner.test/CommandLineTest.cs
+++ b/src/xp.runner.test/CommandLineTest.cs
@@ -269,6 +269,22 @@ namespace Xp.Runners.Test
             Assert.Equal(new Ini[] { }, fixture.EnvFiles.ToArray());
         }
 
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("KEY=", "KEY=")]
+        [InlineData("KEY=value", "KEY=value")]
+        [InlineData("KEY=value\nCOLOR=green", "KEY=value,COLOR=green")]
+        public void environment_variables(string contents, string expected)
+        {
+            var fixture = new CommandLine(new string[] { });
+
+            using (var file = new TemporaryFile(".env.test").Containing(contents))
+            {
+                fixture.TryAddEnv(file.Path);
+                Assert.Equal(expected, string.Join(",", fixture.EnvVariables.Select(e => e.Key + "=" + e.Value)));
+            }
+        }
+
         [Fact]
         public void runonce_is_default_execution_model()
         {

--- a/src/xp.runner.test/CommandLineTest.cs
+++ b/src/xp.runner.test/CommandLineTest.cs
@@ -274,6 +274,7 @@ namespace Xp.Runners.Test
         [InlineData("KEY=", new string[] { "KEY=" })]
         [InlineData("KEY=value", new string[] { "KEY=value" })]
         [InlineData("KEY=value\nCOLOR=green", new string[] { "KEY=value", "COLOR=green" })]
+        [InlineData("KEY=\\$value", new string[] { "KEY=$value" })]
         [InlineData("AUTH=$USER:$PASS", new string[] { "AUTH=testing:" })]
         [InlineData("PASS=secret\nAUTH=$USER:$PASS", new string[] { "PASS=secret", "AUTH=testing:secret" })]
         [InlineData("PASS=secret\nAUTH=${USER}:${PASS}", new string[] { "PASS=secret", "AUTH=testing:secret" })]

--- a/src/xp.runner.test/IniTest.cs
+++ b/src/xp.runner.test/IniTest.cs
@@ -70,36 +70,45 @@ namespace Xp.Runners.Test
         [Fact]
         public void keys_contains_key_with_empty_value()
         {
-            var ini = fixture("key=");
-            Assert.Equal(new string[] {"key"}, ini.Keys("default").ToArray());
+            Assert.Equal(new string[] {"key"}, fixture("key=").Keys("default").ToArray());
         }
 
-        [Fact]
-        public void get_key_from_default_section()
+        [Theory]
+        [InlineData("key=value", "value")]
+        [InlineData("key=`value`", "value")]
+        [InlineData("key='value'", "value")]
+        [InlineData("key=\"value\"", "value")]
+        [InlineData("key='\"Test\"'", "\"Test\"")]
+        [InlineData("key='Timm\\'s'", "Timm's")]
+        [InlineData("key=`Type \\`sh\\``", "Type `sh`")]
+        [InlineData("key=\"A \\\"test\\\"\"", "A \"test\"")]
+        public void get_key_from_default_section(string section, string expected)
         {
-            var ini = fixture("key=value");
-            Assert.Equal("value", ini.Get("default", "key"));
+            Assert.Equal(expected, fixture(section).Get("default", "key"));
         }
 
         [Fact]
         public void get_key_from_section()
         {
-            var ini = fixture("[section]\nkey=value");
-            Assert.Equal("value", ini.Get("section", "key"));
+            Assert.Equal("value", fixture("[section]\nkey=value").Get("section", "key"));
         }
 
         [Fact]
         public void get_empty_value()
         {
-            var ini = fixture("key=");
-            Assert.Equal(null, ini.Get("default", "key"));
+            Assert.Equal(null, fixture("key=").Get("default", "key"));
         }
 
-        [Fact]
-        public void key_and_values_are_trimmed()
+        [Theory]
+        [InlineData("key= value")]
+        [InlineData("key =value")]
+        [InlineData("key = value")]
+        [InlineData(" key = value")]
+        [InlineData("\tkey=value")]
+        [InlineData("key=\tvalue")]
+        public void key_and_values_are_trimmed(string section)
         {
-            var ini = fixture("key = value");
-            Assert.Equal("value", ini.Get("default", "key"));
+            Assert.Equal("value", fixture(section).Get("default", "key"));
         }
 
         [Theory]
@@ -107,9 +116,15 @@ namespace Xp.Runners.Test
         [InlineData("default")]
         public void default_value_returned_for_nonexistant_key_from_get(string section)
         {
-            var ini = fixture("");
             var defaultValue = "defaulted";
-            Assert.Equal(defaultValue, ini.Get(section, "key", defaultValue));
+            Assert.Equal(defaultValue, fixture("").Get(section, "key", defaultValue));
+        }
+
+        [Fact]
+        public void default_value_returned_for_empty_key_from_get()
+        {
+            var defaultValue = "defaulted";
+            Assert.Equal(defaultValue, fixture("key=").Get("default", "key", defaultValue));
         }
 
         [Fact]

--- a/src/xp.runner/Command.cs
+++ b/src/xp.runner/Command.cs
@@ -96,12 +96,9 @@ namespace Xp.Runners
             env["XP_VERSION"] = Assembly.GetExecutingAssembly().GetName().Version.ToString();
             env["XP_MODEL"] = cmd.ExecutionModel.Name;
             env["XP_COMMAND"] = GetType().Name.ToLower();
-            foreach (var config in cmd.EnvFiles)
+            foreach (var pair in cmd.EnvVariables)
             {
-                foreach (var key in config.Keys("default"))
-                {
-                    env[key] = config.Get("default", key).Trim('"');
-                }
+                env[pair.Key] = pair.Value;
             }
 
             return cmd.ExecutionModel.Execute(proc);

--- a/src/xp.runner/Command.cs
+++ b/src/xp.runner/Command.cs
@@ -96,7 +96,7 @@ namespace Xp.Runners
             env["XP_VERSION"] = Assembly.GetExecutingAssembly().GetName().Version.ToString();
             env["XP_MODEL"] = cmd.ExecutionModel.Name;
             env["XP_COMMAND"] = GetType().Name.ToLower();
-            foreach (var pair in cmd.EnvVariables)
+            foreach (var pair in cmd.Expand(env))
             {
                 env[pair.Key] = pair.Value;
             }

--- a/src/xp.runner/Command.cs
+++ b/src/xp.runner/Command.cs
@@ -119,6 +119,13 @@ namespace Xp.Runners
             env["XP_VERSION"] = Assembly.GetExecutingAssembly().GetName().Version.ToString();
             env["XP_MODEL"] = cmd.ExecutionModel.Name;
             env["XP_COMMAND"] = GetType().Name.ToLower();
+            foreach (var config in cmd.EnvFiles)
+            {
+                foreach (var key in config.Keys("default"))
+                {
+                    env[key] = config.Get("default", key).Trim('"');
+                }
+            }
 
             return cmd.ExecutionModel.Execute(proc, encoding);
         }

--- a/src/xp.runner/CommandLine.cs
+++ b/src/xp.runner/CommandLine.cs
@@ -28,6 +28,7 @@ namespace Xp.Runners
             { "-cp?", (self, value) => self.path["classpath"].Add("?" + value) },
             { "-cp!", (self, value) => self.path["classpath"].Add("!" + value) },
             { "-m", (self, value) => self.path["modules"].Add(value) },
+            { "-env", (self, value) => self.envFiles.Add(new Ini(value)) },
             { "-watch", (self, value) => self.executionModel = new RunWatching(value) },
             { "-repeat", (self, value) => self.executionModel = new RunRepeatedly(value) },
             { "-c", (self, value) => self.config = new CompositeConfigSource(
@@ -45,9 +46,10 @@ namespace Xp.Runners
         private Dictionary<string, List<string>> path = new Dictionary<string, List<string>>()
         {
             { "classpath", new List<string>() },
-            { "modules", new List<string>() }
+            { "modules", new List<string>() },
         };
 
+        private List<Ini> envFiles = new List<Ini>();
         private Command command;
         private IEnumerable<string> arguments;
         private ExecutionModel executionModel;
@@ -57,6 +59,12 @@ namespace Xp.Runners
         public Dictionary<string, List<string>> Path
         {
             get { return path; }
+        }
+
+        /// <summary>.env files</summary>
+        public List<Ini> EnvFiles
+        {
+            get { return envFiles; }
         }
 
         /// <summary>Subcommand name</summary>
@@ -114,6 +122,15 @@ namespace Xp.Runners
                     "autoload.php"
                 ));
                 Parse(argv, composer);
+            }
+        }
+
+        /// <summary>Adds an environment file if it exists</summary>
+        public void TryAddEnv(string file)
+        {
+            if (File.Exists(file))
+            {
+                this.envFiles.Add(new Ini(file));
             }
         }
 

--- a/src/xp.runner/CommandLine.cs
+++ b/src/xp.runner/CommandLine.cs
@@ -139,7 +139,7 @@ namespace Xp.Runners
         /// <summary>Expand environment variables</summary>
         public IEnumerable<KeyValuePair<string, string>> Expand(StringDictionary env)
         {
-            var expand = new Regex("(?<!\\\\)\\$((?<name>[a-zA-Z_]+)|{(?<name>[^}]+)})");
+            var expand = new Regex("(?<!\\\\)\\$((?<name>[a-zA-Z0-9_]+)|{(?<name>[^}]+)})");
             foreach (var envFile in envFiles)
             {
                 foreach (var key in envFile.Keys("default"))

--- a/src/xp.runner/CommandLine.cs
+++ b/src/xp.runner/CommandLine.cs
@@ -139,15 +139,16 @@ namespace Xp.Runners
         /// <summary>Expand environment variables</summary>
         public IEnumerable<KeyValuePair<string, string>> Expand(StringDictionary env)
         {
-            var expand = new Regex("\\$((?<name>[a-zA-Z_]+)|{(?<name>[^}]+)})");
+            var expand = new Regex("(?<!\\\\)\\$((?<name>[a-zA-Z_]+)|{(?<name>[^}]+)})");
             foreach (var envFile in envFiles)
             {
                 foreach (var key in envFile.Keys("default"))
                 {
-                    yield return new KeyValuePair<string, string>(key, expand.Replace(
+                    var expanded = expand.Replace(
                         envFile.Get("default", key, ""),
                         match => env[match.Groups["name"].Value] // Doesn't throw if name doesn't exist
-                    ));
+                    );
+                    yield return new KeyValuePair<string, string>(key, expanded.Replace("\\$", "$"));
                 }
             }
         }

--- a/src/xp.runner/CommandLine.cs
+++ b/src/xp.runner/CommandLine.cs
@@ -105,6 +105,20 @@ namespace Xp.Runners
             }
         }
 
+        /// <summary>Environment variables</summary>
+        public IEnumerable<KeyValuePair<string, string>> EnvVariables
+        {
+            get {
+                foreach (var envFile in envFiles)
+                {
+                    foreach (var key in envFile.Keys("default"))
+                    {
+                        yield return new KeyValuePair<string, string>(key, envFile.Get("default", key, ""));
+                    }
+                }
+            }
+        }
+
         /// <summary>Creates the commandline representation from argv</summary>
         public CommandLine(string[] argv)
         {

--- a/src/xp.runner/Xp.cs
+++ b/src/xp.runner/Xp.cs
@@ -38,6 +38,7 @@ namespace Xp.Runners
                 {
                     commandLine.TryAddEnv(".env." + env);
                 }
+                commandLine.TryAddEnv(".env.local");
 
                 try
                 {

--- a/src/xp.runner/Xp.cs
+++ b/src/xp.runner/Xp.cs
@@ -10,7 +10,7 @@ namespace Xp.Runners
     {
 
         /// <summary>Creates a command line based on a composer file</summary>
-        public static CommandLine WithComposer(string[] args)
+        private static CommandLine WithComposer(string[] args)
         {
             try
             {
@@ -31,14 +31,17 @@ namespace Xp.Runners
             {
                 var commandLine = File.Exists(ComposerFile.NAME) ? WithComposer(args) : new CommandLine(args);
 
-                // Load existing environment files
-                commandLine.TryAddEnv(".env");
-                var env = Environment.GetEnvironmentVariable("XP_ENV");
-                if (null != env)
+                // Load existing environment files unless explicitely supplied
+                if (0 == commandLine.EnvFiles.Count)
                 {
-                    commandLine.TryAddEnv(".env." + env);
+                    commandLine.TryAddEnv(".env");
+                    var env = Environment.GetEnvironmentVariable("XP_ENV");
+                    if (null != env)
+                    {
+                        commandLine.TryAddEnv(".env." + env);
+                    }
+                    commandLine.TryAddEnv(".env.local");
                 }
-                commandLine.TryAddEnv(".env.local");
 
                 try
                 {

--- a/src/xp.runner/Xp.cs
+++ b/src/xp.runner/Xp.cs
@@ -8,27 +8,40 @@ namespace Xp.Runners
 {
     public class Xp
     {
+
+        /// <summary>Creates a command line based on a composer file</summary>
+        public static CommandLine WithComposer(string[] args)
+        {
+            try
+            {
+                return new CommandLine(args, new ComposerFile(ComposerFile.NAME));
+            }
+            catch (FileFormatException e)
+            {
+                Console.Error.WriteLine("Warning: {0}", e.Message);
+                // Fall through, continuing as if no composer file was present
+                return new CommandLine(args);
+            }
+        }
+
         /// <summary>Entry point</summary>
         public static int Main(string[] args)
         {
             using (new ConsoleOutput())
             {
+                var commandLine = File.Exists(ComposerFile.NAME) ? WithComposer(args) : new CommandLine(args);
+
+                // Load existing environment files
+                commandLine.TryAddEnv(".env");
+                var env = Environment.GetEnvironmentVariable("XP_ENV");
+                if (null != env)
+                {
+                    commandLine.TryAddEnv(".env." + env);
+                }
+
                 try
                 {
-                    if (File.Exists(ComposerFile.NAME))
-                    {
-                        try
-                        {
-                            return new CommandLine(args, new ComposerFile(ComposerFile.NAME)).Execute();
-                        }
-                        catch (FileFormatException e)
-                        {
-                            Console.Error.WriteLine("Warning: {0}", e.Message);
-                            // Fall through, continuing as if no composer file was present
-                        }
-                    }
-
-                    return new CommandLine(args).Execute();
+                    return commandLine.Execute();
                 }
                 catch (CannotExecute e)
                 {

--- a/src/xp.runner/config/Ini.cs
+++ b/src/xp.runner/config/Ini.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace Xp.Runners.Config
 {
-    class Ini
+    public class Ini
     {
         private static char[] SEPARATOR = new char[] { '=' };
 
@@ -96,6 +96,18 @@ namespace Xp.Runners.Config
             Parse(false);
             if (!sections.ContainsKey(section)) return defaultValue;
             return sections[section].Keys;
+        }
+
+        /// <summary>Tests for equality</summary>
+        public override bool Equals(Object obj)
+        {
+            return obj is Ini && ((Ini) obj).file == this.file;
+        }
+
+        /// <summary>Hashcode implementation</summary>
+        public override int GetHashCode()
+        {
+            return this.file.GetHashCode();
         }
     }
 }

--- a/src/xp.runner/config/Ini.cs
+++ b/src/xp.runner/config/Ini.cs
@@ -62,7 +62,22 @@ namespace Xp.Runners.Config
                         {
                             sections[section][key] = new List<string>();
                         }
-                        if ("" != val)
+                        if (0 == val.Length) continue;
+
+                        // Handle double and single quotes as well as backticks, and their escaping.
+                        if (val.StartsWith("\"") && val.EndsWith("\""))
+                        {
+                            sections[section][key].Add(val.Substring(1, val.Length - 2).Replace("\\\"", "\""));
+                        }
+                        else if (val.StartsWith("'") && val.EndsWith("'"))
+                        {
+                            sections[section][key].Add(val.Substring(1, val.Length - 2).Replace("\\'", "'"));
+                        }
+                        else if (val.StartsWith("`") && val.EndsWith("`"))
+                        {
+                            sections[section][key].Add(val.Substring(1, val.Length - 2).Replace("\\`", "`"));
+                        }
+                        else
                         {
                             sections[section][key].Add(val);
                         }
@@ -78,7 +93,7 @@ namespace Xp.Runners.Config
             Parse(false);
             if (!sections.ContainsKey(section)) return defaultValue;
             if (!sections[section].ContainsKey(key)) return defaultValue;
-            return sections[section][key].FirstOrDefault();
+            return sections[section][key].FirstOrDefault() ?? defaultValue;
         }   
 
         /// <summary>Gets all values for a key</summary>


### PR DESCRIPTION
Implements https://github.com/xp-runners/reference/issues/87, loading environment files if they exist and exposing an `-env` command line to add additional files.

## Setting environment variables

[Like Bun](https://bun.sh/docs/runtime/env), XP runners read the following files automatically:

1. `.env`
2. `.env.production`, `.env.development`, `.env.test` (depending on value of `XP_ENV`)
3. `.env.local`

👉  *Values parsed from later files take precedence over earlier ones.*

## Manually specifying environment files

XP Runners support `-env` to override which specific enviromment file(s) to load. 

```bash
$ xp -env .env.1 test.script.php
$ xp -env .env.1 -env .env.def test.script.php
```

👉 *If `-env` is supplied, no environment files are automatically loaded.*

## Expansion
Environment variables are automatically expanded. This means you can reference previously-defined variables in your environment variables. Curly braces may be used to disambiguate.

```ini
COLOR=green
GREET="Hello $USER, the color is ${COLOR}ish"
```

Yields: "Hello thekid, the color is greenish"

👉 *Nonexistant variables are substituted with an empty string.*

## Examples

Without any environment files:

```bash
$ xp -w '$_ENV["COLOR"] ?? null'
null
```

With *.env* file:

```bash
$ cat > .env
COLOR=green
^D

$ xp -w '$_ENV["COLOR"] ?? null'
green
```

With *.env*  and *.env.prod* files:
```bash
$ cat > .env.prod
COLOR=red
^D

$ xp -w '$_ENV["COLOR"] ?? null'
green

$ xp -env .env.prod -w '$_ENV["COLOR"] ?? null'
red

$ XP_ENV=prod xp -w '$_ENV["COLOR"] ?? null'
red
```

Compose settings:
```bash
$ cat > .env.db
DB_USER=postgres
DB_PASSWORD=secret
DB_HOST=localhost
DB_PORT=5432
DB_URL=postgres://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME

$ DB_NAME=test ./xp.exe -env .env.db -w '$_ENV["DB_URL"]'
postgres://postgres:secret@localhost:5432/test
```